### PR TITLE
fix: restore `doc2graph/data`; correct README CLI; add CPU-safe checkpoint loading (refs #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ uv pip install -e .
 uv run python -m doc2graph.main --init
 
 # Run inference on a document
-uv run python -m doc2graph.main -addG -addT -addE -addV --weights e2e-funsd-best.pt --inference --docs /path/to/your/image.png
+uv run python -m doc2graph.main \
+   -addG -addT -addE -addV \
+   --weights e2e-funsd-best.pt \
+   --inference \
+   --docs /path/to/your/image.png
 ```
 
 Check out the [tutorial notebook](tutorial/kie.ipynb) for a complete walkthrough!
@@ -52,7 +56,11 @@ Index:
 ## News!
 - 🔥 Added **inference** method: you can now use Doc2Graph directly on your documents simply passing a path to them! <br> This call will output an image with the connected entities and a json / dictionary with all the useful information you need! 🤗
 ```
-uv run python -m doc2graph.main -addG -addT -addE -addV --weights e2e-funsd-best.pt --inference --docs /path/to/your/image.png
+uv run python -m doc2graph.main \
+   -addG -addT -addE -addV \
+   --weights e2e-funsd-best.pt \
+   --inference \
+   --docs /path/to/your/image.png
 ```
   
 - 🔥 Added **tutorial** folder: get to know how to use Doc2Graph from the tutorial notebooks!
@@ -120,11 +128,11 @@ You can download our model checkpoints [here](https://drive.google.com/file/d/15
 ## Training
 1. To train our **Doc2Graph** model (using CPU) use:
 ```
-python -m doc2graph.main [SETTINGS]
+uv run python -m doc2graph.main [SETTINGS]
 ```
 2. Instead, to test a trained **Doc2Graph** model (using GPU) [weights can be one or more file]:
 ```
-python -m doc2graph.main [SETTINGS] --gpu 0 --test --weights *.pt
+uv run python -m doc2graph.main [SETTINGS] --gpu 0 --test --weights *.pt
 ```
 The project can be customized either changing directly `configs/base.yaml` file or providing these flags when calling `doc2graph.main`.
 
@@ -164,19 +172,34 @@ You can use our pretrained models over the test sets of FUNSD[^1] and Pau Riba's
 
 **E2E-FUNSD-GT**:
 ```
-python -m doc2graph.main -addG -addT -addE -addV --gpu 0 --test --weights e2e-funsd-best.pt
+uv run python -m doc2graph.main \
+  -addG -addT -addE -addV \
+  --gpu 0 \
+  --test \
+  --weights e2e-funsd-best.pt
 ```
 
 **E2E-FUNSD-YOLO**:
 ```
-python -m doc2graph.main -addG -addT -addE -addV --gpu 0 --test --weights e2e-funsd-best.pt --node-granularity yolo
+uv run python -m doc2graph.main \
+  -addG -addT -addE -addV \
+  --gpu 0 \
+  --test \
+  --weights e2e-funsd-best.pt \
+  --node-granularity yolo
 ```
 
 2. on Pau Riba's dataset, we were able to perform both Layout Analysis and Table Detection
 
 **E2E-PAU**:
 ```
-python -m doc2graph.main -addG -addT -addE -addV --gpu 0 --test --weights e2e-pau-best.pt --src-data PAU --edge-type knn
+uv run python -m doc2graph.main \
+  -addG -addT -addE -addV \
+   --gpu 0 \
+   --test  \
+   --weights e2e-pau-best.pt \
+   --src-data PAU \
+   --edge-type knn
 ```
   
 ---

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ uv sync
 uv pip install -e .
 
 # Initialize the project (downloads datasets)
-uv run doc2graph.main --init
+uv run python -m doc2graph.main --init
 
 # Run inference on a document
 uv run python -m doc2graph.main -addG -addT -addE -addV --weights e2e-funsd-best.pt --inference --docs /path/to/your/image.png
@@ -102,7 +102,7 @@ uv add dgl-cu118 --index-url https://data.dgl.ai/wheels/repo.html
 Finally, create the project folder structure and download data:
 
 ```
-python doc2graph.main --init
+uv run python -m doc2graph.main --init
 ```
 The script will download and setup:
 - FUNSD and the 'adjusted_annotations' for FUNSD[^1] are given by the work of[^3].
@@ -120,11 +120,11 @@ You can download our model checkpoints [here](https://drive.google.com/file/d/15
 ## Training
 1. To train our **Doc2Graph** model (using CPU) use:
 ```
-python doc2graph.main [SETTINGS]
+python -m doc2graph.main [SETTINGS]
 ```
 2. Instead, to test a trained **Doc2Graph** model (using GPU) [weights can be one or more file]:
 ```
-python doc2graph.main [SETTINGS] --gpu 0 --test --weights *.pt
+python -m doc2graph.main [SETTINGS] --gpu 0 --test --weights *.pt
 ```
 The project can be customized either changing directly `configs/base.yaml` file or providing these flags when calling `doc2graph.main`.
 
@@ -164,19 +164,19 @@ You can use our pretrained models over the test sets of FUNSD[^1] and Pau Riba's
 
 **E2E-FUNSD-GT**:
 ```
-python doc2graph.main -addG -addT -addE -addV --gpu 0 --test --weights e2e-funsd-best.pt
+python -m doc2graph.main -addG -addT -addE -addV --gpu 0 --test --weights e2e-funsd-best.pt
 ```
 
 **E2E-FUNSD-YOLO**:
 ```
-python doc2graph.main -addG -addT -addE -addV --gpu 0 --test --weights e2e-funsd-best.pt --node-granularity yolo
+python -m doc2graph.main -addG -addT -addE -addV --gpu 0 --test --weights e2e-funsd-best.pt --node-granularity yolo
 ```
 
 2. on Pau Riba's dataset, we were able to perform both Layout Analysis and Table Detection
 
 **E2E-PAU**:
 ```
-python doc2graph.main -addG -addT -addE -addV --gpu 0 --test --weights e2e-pau-best.pt --src-data PAU --edge-type knn
+python -m doc2graph.main -addG -addT -addE -addV --gpu 0 --test --weights e2e-pau-best.pt --src-data PAU --edge-type knn
 ```
   
 ---

--- a/doc2graph/data/dataloader.py
+++ b/doc2graph/data/dataloader.py
@@ -1,0 +1,195 @@
+from random import randint
+from typing import Tuple
+import torch
+import torch.utils.data as data
+import os
+import numpy as np
+import dgl
+from PIL import Image, ImageDraw
+
+from src.data.feature_builder import FeatureBuilder
+from src.data.graph_builder import GraphBuilder
+from src.utils import get_config
+
+class Document2Graph(data.Dataset):
+    """This class convert documents (both images or pdfs) into graph structures.
+    """
+
+    def __init__(self, name : str, src_path : str, device = str, output_dir = str):
+        """
+        Args:
+            name (str): should be one of the following: ['gt', 'img', 'pdf']
+            src_path (str): path to folder containing documents
+            device (str): device to use. can be 'cpu' or 'cuda:n'
+            output_dir (str): where to save printed graphs examples
+        """
+
+        # initialize class
+        if not os.path.isdir(src_path): raise Exception(f'src_path {src_path} does not exists\n -> please provide an existing path')
+
+        self.name = name
+        self.src_path = src_path
+        self.cfg_preprocessing = get_config('preprocessing')
+        self.src_data = self.cfg_preprocessing.LOADER.src_data
+        self.GB = GraphBuilder()
+        self.FB = FeatureBuilder(device)
+        self.output_dir = output_dir
+
+        # TODO: DO A DIFFERENT FILE
+        self.COLORS = {'invoice_info': (150, 75, 0), 'receiver':(0,100,0), 'other':(128, 128, 128), 'supplier': (255, 0, 255), 'positions':(255,140,0), 'total':(0, 255, 255)}
+
+        # get graphs
+        self.graphs, self.node_labels, self.edge_labels, self.paths = self.__docs2graphs()
+        
+        # LABELS to numeric value
+        # NODES
+        if self.node_labels:
+            self.node_unique_labels = np.unique(np.array([l for nl in self.node_labels for l in nl]))
+            self.node_num_classes = len(self.node_unique_labels)
+            self.node_num_features = self.graphs[0].ndata['feat'].shape[1]
+        
+            for idx, labels in enumerate(self.node_labels):
+                self.graphs[idx].ndata['label'] = torch.tensor([np.where(target == self.node_unique_labels)[0][0] for target in labels], dtype=torch.int64)
+        
+        # EDGES
+        if self.edge_labels:
+            self.edge_unique_labels = np.unique(self.edge_labels[0])
+            self.edge_num_classes = len(self.edge_unique_labels)
+            try:
+                # TODO to be changed
+                self.edge_num_features = self.graphs[0].edata['feat'].shape[1]
+            except:
+                self.edge_num_features = 0
+        
+            for idx, labels in enumerate(self.edge_labels):
+                self.graphs[idx].edata['label'] = torch.tensor([np.where(target == self.edge_unique_labels)[0][0] for target in labels], dtype=torch.int64)
+
+    def __getitem__(self, index: int) -> dgl.DGLGraph:
+        """ Returns item (graph), given index
+
+        Args:
+            index (int): index of the item to be taken.
+        """
+        return self.graphs[index]
+    
+    def __len__(self) -> int:
+        """ Returns data length
+        """
+        return len(self.graphs)
+    
+    def __docs2graphs(self) -> Tuple[list, list, list, list]:
+        """It uses GraphBuilder and FeaturesBuilder objects to get graphs (and lables, if any) from source data.
+
+        Returns:
+            tuple (lists): DGLGraphs, nodes and edges label names, paths per each file
+        """
+        graphs, node_labels, edge_labels, features = self.GB.get_graph(self.src_path, self.src_data)
+        self.feature_chunks, self.num_mods = self.FB.add_features(graphs, features)
+        return graphs, node_labels, edge_labels, features['paths']
+    
+    def label2class(self, label : str, node=True) -> int:
+        """ Transform a label (str) into its class number.
+
+        Args:
+            label (str): node or edge string label
+            node (bool): either if taking node (true) ord edge (false) class number
+        
+        Returns:
+            int: class number
+        """
+        if node:
+            return self.node_unique_labels[label]
+        else:
+            return self.edge_unique_labels[label]
+    
+    def get_info(self, num_graph=0) -> None:
+        """ Print information regarding the data uploaded
+
+        Args:
+            num_graph (int): give one index to print one example graph information
+        """
+        print(f"\n{self.name.upper()} dataset:\n-> graphs: {len(self.graphs)}\n-> node labels: {self.node_unique_labels}\n-> edge labels: {self.edge_unique_labels}\n-> node features: {self.node_num_features}")
+        self.GB.get_info()
+        self.FB.get_info()
+        print(f"-> graph example: {self.graphs[num_graph]}")
+        return
+    
+    def balance(self, cls = 'none', indices = None) -> None:
+        """ Calls balance_edges() of GraphBuilder.
+
+        Args:
+            cls (str): 
+        """
+
+        cls = int(np.where(cls == self.edge_unique_labels)[0][0])
+        if indices is None:
+            for i, g in enumerate(self.graphs):
+                self.graphs[i] = self.GB.balance_edges(g, self.edge_num_classes, cls = cls)
+        else:
+            for id in indices:
+                self.graphs[id] = self.GB.balance_edges(self.graphs[id], self.edge_num_classes, cls = cls)
+        
+        return
+    
+    def get_chunks(self) -> list:
+        """ get feature_chunks, meaning the length of different modalities (features) contributions inside nodes.
+
+        Returns:
+            feature_chunks (list) : list of feature chunks
+        """
+        if len(self.feature_chunks) != self.num_mods: self.feature_chunks.pop(0)
+        return self.feature_chunks
+    
+    def print_graph(self, num=None, node_labels=None, labels_ids=None, name='doc_graph', bidirect=True, regions=[], preds=None) -> Image:
+        """ Print a given graph over its image document.
+
+        Args:
+            num (int): which graph / document to print
+            node_labels (list): list of node labels
+            labels_ids (list): list of labels ids to print
+            name (str): name to give to output file
+            bidirect (bool): either to print the graph bidirected or not
+            regions (list): debug purposes for layout anaylis, if any available it prints it
+            preds (list): if any, it prints model predictions
+        
+        Returns:
+            graph_img (Image) : the drawn graph over the document
+        """
+        if num is None: num = randint(0, self.__len__()-1)
+        graph = self.graphs[num]
+        graph_path = self.paths[num]
+        graph_img = Image.open(graph_path).convert('RGB')
+        if labels_ids is None: labels_ids = graph.edata['label'].nonzero().flatten().tolist()
+        center = lambda rect: ((rect[2]+rect[0])/2, (rect[3]+rect[1])/2)
+        graph_draw = ImageDraw.Draw(graph_img)
+        w, h = graph_img.size
+        boxs = graph.ndata['geom'][:, :4].tolist()
+        boxs = [[box[0]*w, box[1]*h, box[2]*w, box[3]*h] for box in boxs]
+
+        if node_labels is not None:
+            for b, box in enumerate(boxs):
+                label = self.node_unique_labels[node_labels[b]]
+                graph_draw.rectangle(box, outline=self.COLORS[label], width=2)
+        else:
+            for box in boxs:
+                graph_draw.rectangle(box, outline='blue', width=2)
+        
+        for region in regions:
+            color = self.COLORS[region[0]]
+            graph_draw.rectangle(region[1], outline=color, width=4)
+        
+        if preds is not None:
+            graph_draw.rectangle(preds, outline='green', width=4)
+        
+        u,v = graph.edges()
+        for id in labels_ids:
+            sc = center(boxs[u[id]])
+            ec = center(boxs[v[id]])
+            graph_draw.line((sc,ec), fill='violet', width=3)
+            if bidirect:
+                graph_draw.ellipse([(sc[0]-4,sc[1]-4), (sc[0]+4,sc[1]+4)], fill = 'green', outline='black')
+                graph_draw.ellipse([(ec[0]-4,ec[1]-4), (ec[0]+4,ec[1]+4)], fill = 'red', outline='black')
+
+        graph_img.save(self.output_dir / f'{name}.png')
+        return graph_img
+        

--- a/doc2graph/data/dataloader.py
+++ b/doc2graph/data/dataloader.py
@@ -1,21 +1,22 @@
+import os
 from random import randint
 from typing import Tuple
+
+import dgl
+import numpy as np
 import torch
 import torch.utils.data as data
-import os
-import numpy as np
-import dgl
 from PIL import Image, ImageDraw
 
-from src.data.feature_builder import FeatureBuilder
-from src.data.graph_builder import GraphBuilder
-from src.utils import get_config
+from ..data.feature_builder import FeatureBuilder
+from ..data.graph_builder import GraphBuilder
+from ..utils import get_config
+
 
 class Document2Graph(data.Dataset):
-    """This class convert documents (both images or pdfs) into graph structures.
-    """
+    """This class convert documents (both images or pdfs) into graph structures."""
 
-    def __init__(self, name : str, src_path : str, device = str, output_dir = str):
+    def __init__(self, name: str, src_path: str, device=str, output_dir=str):
         """
         Args:
             name (str): should be one of the following: ['gt', 'img', 'pdf']
@@ -25,75 +26,102 @@ class Document2Graph(data.Dataset):
         """
 
         # initialize class
-        if not os.path.isdir(src_path): raise Exception(f'src_path {src_path} does not exists\n -> please provide an existing path')
+        if not os.path.isdir(src_path):
+            raise Exception(
+                f"src_path {src_path} does not exists\n -> please provide an existing path"
+            )
 
         self.name = name
         self.src_path = src_path
-        self.cfg_preprocessing = get_config('preprocessing')
+        self.cfg_preprocessing = get_config("preprocessing")
         self.src_data = self.cfg_preprocessing.LOADER.src_data
         self.GB = GraphBuilder()
         self.FB = FeatureBuilder(device)
         self.output_dir = output_dir
 
         # TODO: DO A DIFFERENT FILE
-        self.COLORS = {'invoice_info': (150, 75, 0), 'receiver':(0,100,0), 'other':(128, 128, 128), 'supplier': (255, 0, 255), 'positions':(255,140,0), 'total':(0, 255, 255)}
+        self.COLORS = {
+            "invoice_info": (150, 75, 0),
+            "receiver": (0, 100, 0),
+            "other": (128, 128, 128),
+            "supplier": (255, 0, 255),
+            "positions": (255, 140, 0),
+            "total": (0, 255, 255),
+        }
 
         # get graphs
-        self.graphs, self.node_labels, self.edge_labels, self.paths = self.__docs2graphs()
-        
+        self.graphs, self.node_labels, self.edge_labels, self.paths = (
+            self.__docs2graphs()
+        )
+
         # LABELS to numeric value
         # NODES
         if self.node_labels:
-            self.node_unique_labels = np.unique(np.array([l for nl in self.node_labels for l in nl]))
+            self.node_unique_labels = np.unique(
+                np.array([l for nl in self.node_labels for l in nl])
+            )
             self.node_num_classes = len(self.node_unique_labels)
-            self.node_num_features = self.graphs[0].ndata['feat'].shape[1]
-        
+            self.node_num_features = self.graphs[0].ndata["feat"].shape[1]
+
             for idx, labels in enumerate(self.node_labels):
-                self.graphs[idx].ndata['label'] = torch.tensor([np.where(target == self.node_unique_labels)[0][0] for target in labels], dtype=torch.int64)
-        
+                self.graphs[idx].ndata["label"] = torch.tensor(
+                    [
+                        np.where(target == self.node_unique_labels)[0][0]
+                        for target in labels
+                    ],
+                    dtype=torch.int64,
+                )
+
         # EDGES
         if self.edge_labels:
             self.edge_unique_labels = np.unique(self.edge_labels[0])
             self.edge_num_classes = len(self.edge_unique_labels)
             try:
                 # TODO to be changed
-                self.edge_num_features = self.graphs[0].edata['feat'].shape[1]
+                self.edge_num_features = self.graphs[0].edata["feat"].shape[1]
             except:
                 self.edge_num_features = 0
-        
+
             for idx, labels in enumerate(self.edge_labels):
-                self.graphs[idx].edata['label'] = torch.tensor([np.where(target == self.edge_unique_labels)[0][0] for target in labels], dtype=torch.int64)
+                self.graphs[idx].edata["label"] = torch.tensor(
+                    [
+                        np.where(target == self.edge_unique_labels)[0][0]
+                        for target in labels
+                    ],
+                    dtype=torch.int64,
+                )
 
     def __getitem__(self, index: int) -> dgl.DGLGraph:
-        """ Returns item (graph), given index
+        """Returns item (graph), given index
 
         Args:
             index (int): index of the item to be taken.
         """
         return self.graphs[index]
-    
+
     def __len__(self) -> int:
-        """ Returns data length
-        """
+        """Returns data length"""
         return len(self.graphs)
-    
+
     def __docs2graphs(self) -> Tuple[list, list, list, list]:
         """It uses GraphBuilder and FeaturesBuilder objects to get graphs (and lables, if any) from source data.
 
         Returns:
             tuple (lists): DGLGraphs, nodes and edges label names, paths per each file
         """
-        graphs, node_labels, edge_labels, features = self.GB.get_graph(self.src_path, self.src_data)
+        graphs, node_labels, edge_labels, features = self.GB.get_graph(
+            self.src_path, self.src_data
+        )
         self.feature_chunks, self.num_mods = self.FB.add_features(graphs, features)
-        return graphs, node_labels, edge_labels, features['paths']
-    
-    def label2class(self, label : str, node=True) -> int:
-        """ Transform a label (str) into its class number.
+        return graphs, node_labels, edge_labels, features["paths"]
+
+    def label2class(self, label: str, node=True) -> int:
+        """Transform a label (str) into its class number.
 
         Args:
             label (str): node or edge string label
             node (bool): either if taking node (true) ord edge (false) class number
-        
+
         Returns:
             int: class number
         """
@@ -101,47 +129,63 @@ class Document2Graph(data.Dataset):
             return self.node_unique_labels[label]
         else:
             return self.edge_unique_labels[label]
-    
+
     def get_info(self, num_graph=0) -> None:
-        """ Print information regarding the data uploaded
+        """Print information regarding the data uploaded
 
         Args:
             num_graph (int): give one index to print one example graph information
         """
-        print(f"\n{self.name.upper()} dataset:\n-> graphs: {len(self.graphs)}\n-> node labels: {self.node_unique_labels}\n-> edge labels: {self.edge_unique_labels}\n-> node features: {self.node_num_features}")
+        print(
+            f"\n{self.name.upper()} dataset:\n-> graphs: {len(self.graphs)}\n-> node labels: {self.node_unique_labels}\n-> edge labels: {self.edge_unique_labels}\n-> node features: {self.node_num_features}"
+        )
         self.GB.get_info()
         self.FB.get_info()
         print(f"-> graph example: {self.graphs[num_graph]}")
         return
-    
-    def balance(self, cls = 'none', indices = None) -> None:
-        """ Calls balance_edges() of GraphBuilder.
+
+    def balance(self, cls="none", indices=None) -> None:
+        """Calls balance_edges() of GraphBuilder.
 
         Args:
-            cls (str): 
+            cls (str):
         """
 
         cls = int(np.where(cls == self.edge_unique_labels)[0][0])
         if indices is None:
             for i, g in enumerate(self.graphs):
-                self.graphs[i] = self.GB.balance_edges(g, self.edge_num_classes, cls = cls)
+                self.graphs[i] = self.GB.balance_edges(
+                    g, self.edge_num_classes, cls=cls
+                )
         else:
             for id in indices:
-                self.graphs[id] = self.GB.balance_edges(self.graphs[id], self.edge_num_classes, cls = cls)
-        
+                self.graphs[id] = self.GB.balance_edges(
+                    self.graphs[id], self.edge_num_classes, cls=cls
+                )
+
         return
-    
+
     def get_chunks(self) -> list:
-        """ get feature_chunks, meaning the length of different modalities (features) contributions inside nodes.
+        """get feature_chunks, meaning the length of different modalities (features) contributions inside nodes.
 
         Returns:
             feature_chunks (list) : list of feature chunks
         """
-        if len(self.feature_chunks) != self.num_mods: self.feature_chunks.pop(0)
+        if len(self.feature_chunks) != self.num_mods:
+            self.feature_chunks.pop(0)
         return self.feature_chunks
-    
-    def print_graph(self, num=None, node_labels=None, labels_ids=None, name='doc_graph', bidirect=True, regions=[], preds=None) -> Image:
-        """ Print a given graph over its image document.
+
+    def print_graph(
+        self,
+        num=None,
+        node_labels=None,
+        labels_ids=None,
+        name="doc_graph",
+        bidirect=True,
+        regions=[],
+        preds=None,
+    ) -> Image:
+        """Print a given graph over its image document.
 
         Args:
             num (int): which graph / document to print
@@ -151,20 +195,22 @@ class Document2Graph(data.Dataset):
             bidirect (bool): either to print the graph bidirected or not
             regions (list): debug purposes for layout anaylis, if any available it prints it
             preds (list): if any, it prints model predictions
-        
+
         Returns:
             graph_img (Image) : the drawn graph over the document
         """
-        if num is None: num = randint(0, self.__len__()-1)
+        if num is None:
+            num = randint(0, self.__len__() - 1)
         graph = self.graphs[num]
         graph_path = self.paths[num]
-        graph_img = Image.open(graph_path).convert('RGB')
-        if labels_ids is None: labels_ids = graph.edata['label'].nonzero().flatten().tolist()
-        center = lambda rect: ((rect[2]+rect[0])/2, (rect[3]+rect[1])/2)
+        graph_img = Image.open(graph_path).convert("RGB")
+        if labels_ids is None:
+            labels_ids = graph.edata["label"].nonzero().flatten().tolist()
+        center = lambda rect: ((rect[2] + rect[0]) / 2, (rect[3] + rect[1]) / 2)
         graph_draw = ImageDraw.Draw(graph_img)
         w, h = graph_img.size
-        boxs = graph.ndata['geom'][:, :4].tolist()
-        boxs = [[box[0]*w, box[1]*h, box[2]*w, box[3]*h] for box in boxs]
+        boxs = graph.ndata["geom"][:, :4].tolist()
+        boxs = [[box[0] * w, box[1] * h, box[2] * w, box[3] * h] for box in boxs]
 
         if node_labels is not None:
             for b, box in enumerate(boxs):
@@ -172,24 +218,31 @@ class Document2Graph(data.Dataset):
                 graph_draw.rectangle(box, outline=self.COLORS[label], width=2)
         else:
             for box in boxs:
-                graph_draw.rectangle(box, outline='blue', width=2)
-        
+                graph_draw.rectangle(box, outline="blue", width=2)
+
         for region in regions:
             color = self.COLORS[region[0]]
             graph_draw.rectangle(region[1], outline=color, width=4)
-        
+
         if preds is not None:
-            graph_draw.rectangle(preds, outline='green', width=4)
-        
-        u,v = graph.edges()
+            graph_draw.rectangle(preds, outline="green", width=4)
+
+        u, v = graph.edges()
         for id in labels_ids:
             sc = center(boxs[u[id]])
             ec = center(boxs[v[id]])
-            graph_draw.line((sc,ec), fill='violet', width=3)
+            graph_draw.line((sc, ec), fill="violet", width=3)
             if bidirect:
-                graph_draw.ellipse([(sc[0]-4,sc[1]-4), (sc[0]+4,sc[1]+4)], fill = 'green', outline='black')
-                graph_draw.ellipse([(ec[0]-4,ec[1]-4), (ec[0]+4,ec[1]+4)], fill = 'red', outline='black')
+                graph_draw.ellipse(
+                    [(sc[0] - 4, sc[1] - 4), (sc[0] + 4, sc[1] + 4)],
+                    fill="green",
+                    outline="black",
+                )
+                graph_draw.ellipse(
+                    [(ec[0] - 4, ec[1] - 4), (ec[0] + 4, ec[1] + 4)],
+                    fill="red",
+                    outline="black",
+                )
 
-        graph_img.save(self.output_dir / f'{name}.png')
+        graph_img.save(self.output_dir / f"{name}.png")
         return graph_img
-        

--- a/doc2graph/data/download.py
+++ b/doc2graph/data/download.py
@@ -1,0 +1,93 @@
+import os
+import shutil
+import requests
+import zipfile
+import wget
+from src.utils import create_folder
+
+from src.paths import CHECKPOINTS, DATA
+
+def download_url(url, save_path, chunk_size=128):
+    r = requests.get(url, stream=True)
+    with open(save_path, 'wb') as fd:
+        for chunk in r.iter_content(chunk_size=chunk_size):
+            fd.write(chunk)
+
+def funsd():
+    print("Downloading FUNSD")
+
+    dlz = DATA / 'funsd.zip'
+    download_url("https://guillaumejaume.github.io/FUNSD/dataset.zip", dlz)
+    with zipfile.ZipFile(dlz, 'r') as zip_ref:
+        zip_ref.extractall(DATA)
+    os.remove(dlz)
+    os.rename(DATA / 'dataset', DATA / 'FUNSD')
+
+    # adjusted annotations
+    aa_train = os.path.join(DATA / 'adjusted_annotations.zip')
+    wget.download(url="https://docs.google.com/uc?export=download&id=1cQE2dnLGh93u3xMUeGQRXM81tF2l0Zut", out=aa_train)
+    with zipfile.ZipFile(aa_train, 'r') as zip_ref:
+        zip_ref.extractall(DATA / 'FUNSD/training_data')
+    os.remove(aa_train)
+    
+    aa_test = os.path.join(DATA / 'adjusted_annotations.zip')
+    wget.download(url="https://docs.google.com/uc?export=download&id=18LXbRhjnkdsAvWBFhUdr7_44bfaBo0-v", out=aa_test)
+    with zipfile.ZipFile(aa_test, 'r') as zip_ref:
+        zip_ref.extractall(DATA / 'FUNSD/testing_data')
+    os.remove(aa_test)
+
+    # yolo_bbox
+    yolo_train = os.path.join(DATA / 'yolo_bbox.zip')
+    
+    
+    wget.download(url="https://docs.google.com/uc?export=download&id=1UzL5tYtBWDXk_nXj4KtoDMyBt7S3j-aS", out=yolo_train)
+    with zipfile.ZipFile(yolo_train, 'r') as zip_ref:
+        zip_ref.extractall(DATA / 'FUNSD/training_data')
+    os.remove(yolo_train)
+    
+    yolo_test = os.path.join(DATA / 'yolo_bbox.zip')
+    wget.download(url="https://docs.google.com/uc?export=download&id=1fWwbhfvINYFQmoPHpwlH8olyTyJPIe_-", out=yolo_test)
+    with zipfile.ZipFile(yolo_test, 'r') as zip_ref:
+        zip_ref.extractall(DATA / 'FUNSD/testing_data')
+    os.remove(yolo_test)
+
+    return
+
+def pau():
+
+    print("Downloading PAU")
+
+    PAU = DATA / 'PAU'
+    spl = os.path.join(DATA, 'pau_split.zip')
+    wget.download(url="https://docs.google.com/uc?export=download&id=1NKlME13tRIDraSid7r3v_huTqFdHgo-G", out=spl)
+    with zipfile.ZipFile(spl, 'r') as zip_ref:
+        zip_ref.extractall(PAU)
+
+    dlz = DATA / 'pau.zip'
+    download_url("https://zenodo.org/record/3257319/files/dataset.zip", dlz)
+    with zipfile.ZipFile(dlz, 'r') as zip_ref:
+        zip_ref.extractall(PAU)
+    
+    create_folder(PAU / 'train')
+    create_folder(PAU / 'test')
+    create_folder(PAU / 'outliers')
+
+    for split in ['train.txt', 'test.txt', 'outliers.txt']:
+        with open(PAU / split, mode='r') as f:
+            folder = split.split(".")[0]
+            lines = f.readlines()
+            for l in lines:
+                l = l.rstrip('\n')
+                src = PAU / l
+                dst = PAU / '{}/{}'.format(folder, l)
+                shutil.move(src, dst)
+            
+    os.remove(spl)
+    os.remove(dlz)
+    return
+
+def get_data():
+    funsd()
+    pau()
+    return
+

--- a/doc2graph/data/download.py
+++ b/doc2graph/data/download.py
@@ -1,93 +1,110 @@
 import os
 import shutil
-import requests
 import zipfile
-import wget
-from src.utils import create_folder
 
-from src.paths import CHECKPOINTS, DATA
+import requests
+import wget
+
+from ..paths import DATA
+from ..utils import create_folder
+
 
 def download_url(url, save_path, chunk_size=128):
     r = requests.get(url, stream=True)
-    with open(save_path, 'wb') as fd:
+    with open(save_path, "wb") as fd:
         for chunk in r.iter_content(chunk_size=chunk_size):
             fd.write(chunk)
+
 
 def funsd():
     print("Downloading FUNSD")
 
-    dlz = DATA / 'funsd.zip'
+    dlz = DATA / "funsd.zip"
     download_url("https://guillaumejaume.github.io/FUNSD/dataset.zip", dlz)
-    with zipfile.ZipFile(dlz, 'r') as zip_ref:
+    with zipfile.ZipFile(dlz, "r") as zip_ref:
         zip_ref.extractall(DATA)
     os.remove(dlz)
-    os.rename(DATA / 'dataset', DATA / 'FUNSD')
+    os.rename(DATA / "dataset", DATA / "FUNSD")
 
     # adjusted annotations
-    aa_train = os.path.join(DATA / 'adjusted_annotations.zip')
-    wget.download(url="https://docs.google.com/uc?export=download&id=1cQE2dnLGh93u3xMUeGQRXM81tF2l0Zut", out=aa_train)
-    with zipfile.ZipFile(aa_train, 'r') as zip_ref:
-        zip_ref.extractall(DATA / 'FUNSD/training_data')
+    aa_train = os.path.join(DATA / "adjusted_annotations.zip")
+    wget.download(
+        url="https://docs.google.com/uc?export=download&id=1cQE2dnLGh93u3xMUeGQRXM81tF2l0Zut",
+        out=aa_train,
+    )
+    with zipfile.ZipFile(aa_train, "r") as zip_ref:
+        zip_ref.extractall(DATA / "FUNSD/training_data")
     os.remove(aa_train)
-    
-    aa_test = os.path.join(DATA / 'adjusted_annotations.zip')
-    wget.download(url="https://docs.google.com/uc?export=download&id=18LXbRhjnkdsAvWBFhUdr7_44bfaBo0-v", out=aa_test)
-    with zipfile.ZipFile(aa_test, 'r') as zip_ref:
-        zip_ref.extractall(DATA / 'FUNSD/testing_data')
+
+    aa_test = os.path.join(DATA / "adjusted_annotations.zip")
+    wget.download(
+        url="https://docs.google.com/uc?export=download&id=18LXbRhjnkdsAvWBFhUdr7_44bfaBo0-v",
+        out=aa_test,
+    )
+    with zipfile.ZipFile(aa_test, "r") as zip_ref:
+        zip_ref.extractall(DATA / "FUNSD/testing_data")
     os.remove(aa_test)
 
     # yolo_bbox
-    yolo_train = os.path.join(DATA / 'yolo_bbox.zip')
-    
-    
-    wget.download(url="https://docs.google.com/uc?export=download&id=1UzL5tYtBWDXk_nXj4KtoDMyBt7S3j-aS", out=yolo_train)
-    with zipfile.ZipFile(yolo_train, 'r') as zip_ref:
-        zip_ref.extractall(DATA / 'FUNSD/training_data')
+    yolo_train = os.path.join(DATA / "yolo_bbox.zip")
+
+    wget.download(
+        url="https://docs.google.com/uc?export=download&id=1UzL5tYtBWDXk_nXj4KtoDMyBt7S3j-aS",
+        out=yolo_train,
+    )
+    with zipfile.ZipFile(yolo_train, "r") as zip_ref:
+        zip_ref.extractall(DATA / "FUNSD/training_data")
     os.remove(yolo_train)
-    
-    yolo_test = os.path.join(DATA / 'yolo_bbox.zip')
-    wget.download(url="https://docs.google.com/uc?export=download&id=1fWwbhfvINYFQmoPHpwlH8olyTyJPIe_-", out=yolo_test)
-    with zipfile.ZipFile(yolo_test, 'r') as zip_ref:
-        zip_ref.extractall(DATA / 'FUNSD/testing_data')
+
+    yolo_test = os.path.join(DATA / "yolo_bbox.zip")
+    wget.download(
+        url="https://docs.google.com/uc?export=download&id=1fWwbhfvINYFQmoPHpwlH8olyTyJPIe_-",
+        out=yolo_test,
+    )
+    with zipfile.ZipFile(yolo_test, "r") as zip_ref:
+        zip_ref.extractall(DATA / "FUNSD/testing_data")
     os.remove(yolo_test)
 
     return
 
-def pau():
 
+def pau():
     print("Downloading PAU")
 
-    PAU = DATA / 'PAU'
-    spl = os.path.join(DATA, 'pau_split.zip')
-    wget.download(url="https://docs.google.com/uc?export=download&id=1NKlME13tRIDraSid7r3v_huTqFdHgo-G", out=spl)
-    with zipfile.ZipFile(spl, 'r') as zip_ref:
+    PAU = DATA / "PAU"
+    spl = os.path.join(DATA, "pau_split.zip")
+    wget.download(
+        url="https://docs.google.com/uc?export=download&id=1NKlME13tRIDraSid7r3v_huTqFdHgo-G",
+        out=spl,
+    )
+    with zipfile.ZipFile(spl, "r") as zip_ref:
         zip_ref.extractall(PAU)
 
-    dlz = DATA / 'pau.zip'
+    dlz = DATA / "pau.zip"
     download_url("https://zenodo.org/record/3257319/files/dataset.zip", dlz)
-    with zipfile.ZipFile(dlz, 'r') as zip_ref:
+    with zipfile.ZipFile(dlz, "r") as zip_ref:
         zip_ref.extractall(PAU)
-    
-    create_folder(PAU / 'train')
-    create_folder(PAU / 'test')
-    create_folder(PAU / 'outliers')
 
-    for split in ['train.txt', 'test.txt', 'outliers.txt']:
-        with open(PAU / split, mode='r') as f:
+    create_folder(PAU / "train")
+    create_folder(PAU / "test")
+    create_folder(PAU / "outliers")
+
+    for split in ["train.txt", "test.txt", "outliers.txt"]:
+        with open(PAU / split, mode="r") as f:
             folder = split.split(".")[0]
             lines = f.readlines()
             for l in lines:
-                l = l.rstrip('\n')
+                l = l.rstrip("\n")
                 src = PAU / l
-                dst = PAU / '{}/{}'.format(folder, l)
+                dst = PAU / "{}/{}".format(folder, l)
                 shutil.move(src, dst)
-            
+
     os.remove(spl)
     os.remove(dlz)
     return
+
 
 def get_data():
     funsd()
     pau()
     return
-

--- a/doc2graph/data/feature_builder.py
+++ b/doc2graph/data/feature_builder.py
@@ -1,27 +1,27 @@
 import random
 from typing import Tuple
+
 import spacy
 import torch
 import torchvision
-from tqdm import tqdm
-from PIL import Image, ImageDraw
 import torchvision.transforms.functional as tvF
+from PIL import Image, ImageDraw
+from tqdm import tqdm
 
-from src.paths import CHECKPOINTS
-from src.models.unet import Unet
-from src.data.utils import to_bin
-from src.data.utils import polar, get_histogram
-from src.utils import get_config
+from ..data.utils import get_histogram, polar, to_bin
+from ..models.unet import Unet
+from ..paths import CHECKPOINTS
+from ..utils import get_config
 
-class FeatureBuilder():
 
-    def __init__(self, d : int = 'cpu'):
+class FeatureBuilder:
+    def __init__(self, d: str | torch.device = "cpu"):
         """FeatureBuilder constructor
 
         Args:
             d (int): device number, if any (cpu or cuda:n)
         """
-        self.cfg_preprocessing = get_config('preprocessing')
+        self.cfg_preprocessing = get_config("preprocessing")
         self.device = d
         self.add_geom = self.cfg_preprocessing.FEATURES.add_geom
         self.add_embs = self.cfg_preprocessing.FEATURES.add_embs
@@ -32,72 +32,107 @@ class FeatureBuilder():
         self.num_polar_bins = self.cfg_preprocessing.FEATURES.num_polar_bins
 
         if self.add_embs:
-            self.text_embedder = spacy.load('en_core_web_lg')
+            self.text_embedder = spacy.load("en_core_web_lg")
 
         if self.add_visual:
-            self.visual_embedder = Unet(encoder_name="mobilenet_v2", encoder_weights=None, in_channels=1, classes=4)
-            self.visual_embedder.load_state_dict(torch.load(CHECKPOINTS / 'backbone_unet.pth')['weights'])
+            self.visual_embedder = Unet(
+                encoder_name="mobilenet_v2",
+                encoder_weights=None,
+                in_channels=1,
+                classes=4,
+            )
+            self.visual_embedder.load_state_dict(
+                torch.load(CHECKPOINTS / "backbone_unet.pth", map_location=self.device)[
+                    "weights"
+                ]
+            )
             self.visual_embedder = self.visual_embedder.encoder
             self.visual_embedder.to(d)
-        
-        self.sg = lambda rect, s : [rect[0]/s[0], rect[1]/s[1], rect[2]/s[0], rect[3]/s[1]] # scaling by img width and height
-    
-    def add_features(self, graphs : list, features : list) -> Tuple[list, int]:
-        """ Add features to provided graphs
+
+        self.sg = lambda rect, s: [
+            rect[0] / s[0],
+            rect[1] / s[1],
+            rect[2] / s[0],
+            rect[3] / s[1],
+        ]  # scaling by img width and height
+
+    def add_features(self, graphs: list, features: list) -> Tuple[list, int]:
+        """Add features to provided graphs
 
         Args:
             graphs (list) : list of DGLGraphs
             features (list) : list of features "sources", like text, positions and images
-        
+
         Returns:
             chunks list and its lenght
         """
 
-        for id, g in enumerate(tqdm(graphs, desc='adding features')):
-
+        for id, g in enumerate(tqdm(graphs, desc="adding features")):
             # positional features
-            size = Image.open(features['paths'][id]).size
-            feats = [[] for _ in range(len(features['boxs'][id]))]
-            geom = [self.sg(box, size) for box in features['boxs'][id]]
+            size = Image.open(features["paths"][id]).size
+            feats = [[] for _ in range(len(features["boxs"][id]))]
+            geom = [self.sg(box, size) for box in features["boxs"][id]]
             chunks = []
 
             # 'geometrical' features
             if self.add_geom:
-                
                 # TODO add 2d encoding like "LayoutLM*"
-                [feats[idx].extend(self.sg(box, size)) for idx, box in enumerate(features['boxs'][id])]
+                [
+                    feats[idx].extend(self.sg(box, size))
+                    for idx, box in enumerate(features["boxs"][id])
+                ]
                 chunks.append(4)
-            
+
             # HISTOGRAM OF TEXT
             if self.add_hist:
-                
-                [feats[idx].extend(hist) for idx, hist in enumerate(get_histogram(features['texts'][id]))]
+                [
+                    feats[idx].extend(hist)
+                    for idx, hist in enumerate(get_histogram(features["texts"][id]))
+                ]
                 chunks.append(4)
-            
+
             # textual features
             if self.add_embs:
-                
                 # LANGUAGE MODEL (SPACY)
-                [feats[idx].extend(self.text_embedder(features['texts'][id][idx]).vector) for idx, _ in enumerate(feats)]
-                chunks.append(len(self.text_embedder(features['texts'][id][0]).vector))
-            
+                [
+                    feats[idx].extend(
+                        self.text_embedder(features["texts"][id][idx]).vector
+                    )
+                    for idx, _ in enumerate(feats)
+                ]
+                chunks.append(len(self.text_embedder(features["texts"][id][0]).vector))
+
             # visual features
             # https://pytorch.org/vision/stable/generated/torchvision.ops.roi_align.html?highlight=roi
             if self.add_visual:
-                img = Image.open(features['paths'][id])
-                visual_emb = self.visual_embedder(tvF.to_tensor(img).unsqueeze_(0).to(self.device)) # output [batch, channels, dim1, dim2]
-                bboxs = [torch.Tensor(b) for b in features['boxs'][id]]
+                img = Image.open(features["paths"][id])
+                visual_emb = self.visual_embedder(
+                    tvF.to_tensor(img).unsqueeze_(0).to(self.device)
+                )  # output [batch, channels, dim1, dim2]
+                bboxs = [torch.Tensor(b) for b in features["boxs"][id]]
                 bboxs = [torch.stack(bboxs, dim=0).to(self.device)]
-                h = [torchvision.ops.roi_align(input=ve, boxes=bboxs, spatial_scale=1/ min(size[1] / ve.shape[2] , size[0] / ve.shape[3]), output_size=1) for ve in visual_emb[1:]]
+                h = [
+                    torchvision.ops.roi_align(
+                        input=ve,
+                        boxes=bboxs,
+                        spatial_scale=1
+                        / min(size[1] / ve.shape[2], size[0] / ve.shape[3]),
+                        output_size=1,
+                    )
+                    for ve in visual_emb[1:]
+                ]
                 h = torch.cat(h, dim=1)
 
                 # VISUAL FEATURES (RESNET-IMAGENET)
-                [feats[idx].extend(torch.flatten(h[idx]).tolist()) for idx, _ in enumerate(feats)]
+                [
+                    feats[idx].extend(torch.flatten(h[idx]).tolist())
+                    for idx, _ in enumerate(feats)
+                ]
                 chunks.append(len(torch.flatten(h[0]).tolist()))
-        
+
             if self.add_eweights:
                 u, v = g.edges()
-                srcs, dsts =  u.tolist(), v.tolist()
+                srcs, dsts = u.tolist(), v.tolist()
                 distances = []
                 angles = []
 
@@ -105,61 +140,76 @@ class FeatureBuilder():
                 #! with fully connected simply normalized with max distance between distances
                 # m = sqrt((size[0]*size[0] + size[1]*size[1]))
                 # parable = lambda x : (-x+1)**4
-                
+
                 for pair in zip(srcs, dsts):
-                    dist, angle = polar(features['boxs'][id][pair[0]], features['boxs'][id][pair[1]])
+                    dist, angle = polar(
+                        features["boxs"][id][pair[0]], features["boxs"][id][pair[1]]
+                    )
                     distances.append(dist)
                     angles.append(angle)
-                
+
                 m = max(distances)
                 polar_coordinates = to_bin(distances, angles, self.num_polar_bins)
-                g.edata['feat'] = polar_coordinates
+                g.edata["feat"] = polar_coordinates
 
             else:
-                distances = ([0.0 for _ in range(g.number_of_edges())])
+                distances = [0.0 for _ in range(g.number_of_edges())]
                 m = 1
 
-            g.ndata['geom'] = torch.tensor(geom, dtype=torch.float32)
-            g.ndata['feat'] = torch.tensor(feats, dtype=torch.float32)
+            g.ndata["geom"] = torch.tensor(geom, dtype=torch.float32)
+            g.ndata["feat"] = torch.tensor(feats, dtype=torch.float32)
 
-            distances = torch.tensor([(1-d/m) for d in distances], dtype=torch.float32)
-            tresh_dist = torch.where(distances > 0.9, torch.full_like(distances, 0.1), torch.zeros_like(distances))
-            g.edata['weights'] = tresh_dist
+            distances = torch.tensor(
+                [(1 - d / m) for d in distances], dtype=torch.float32
+            )
+            tresh_dist = torch.where(
+                distances > 0.9,
+                torch.full_like(distances, 0.1),
+                torch.zeros_like(distances),
+            )
+            g.edata["weights"] = tresh_dist
 
             norm = []
-            num_nodes = len(features['boxs'][id]) - 1
+            num_nodes = len(features["boxs"][id]) - 1
             for n in range(num_nodes + 1):
-                neigs = torch.count_nonzero(tresh_dist[n*num_nodes:(n+1)*num_nodes]).tolist()
-                try: norm.append([1. / neigs])
-                except: norm.append([1.])
-            g.ndata['norm'] = torch.tensor(norm, dtype=torch.float32)
+                neigs = torch.count_nonzero(
+                    tresh_dist[n * num_nodes : (n + 1) * num_nodes]
+                ).tolist()
+                try:
+                    norm.append([1.0 / neigs])
+                except:
+                    norm.append([1.0])
+            g.ndata["norm"] = torch.tensor(norm, dtype=torch.float32)
 
             #! DEBUG PURPOSES TO VISUALIZE RANDOM GRAPH IMAGE FROM DATASET
             if False:
                 if id == rand_id and self.add_eweights:
                     print("\n\n### EXAMPLE ###")
 
-                    img_path = features['paths'][id]
-                    img = Image.open(img_path).convert('RGB')
+                    img_path = features["paths"][id]
+                    img = Image.open(img_path).convert("RGB")
                     draw = ImageDraw.Draw(img)
 
-                    center = lambda rect: ((rect[2]+rect[0])/2, (rect[3]+rect[1])/2)
+                    center = lambda rect: (
+                        (rect[2] + rect[0]) / 2,
+                        (rect[3] + rect[1]) / 2,
+                    )
                     select = [random.randint(0, len(srcs)) for _ in range(10)]
                     for p, pair in enumerate(zip(srcs, dsts)):
                         if p in select:
-                            sc = center(features['boxs'][id][pair[0]])
-                            ec = center(features['boxs'][id][pair[1]])
-                            draw.line((sc, ec), fill='grey', width=3)
-                            middle_point = ((sc[0] + ec[0])/2,(sc[1] + ec[1])/2)
-                            draw.text(middle_point, str(angles[p]), fill='black')
-                            draw.rectangle(features['boxs'][id][pair[0]], fill='red')
-                            draw.rectangle(features['boxs'][id][pair[1]], fill='blue')
-                    
-                    img.save(f'esempi/FUNSD/edges.png')
+                            sc = center(features["boxs"][id][pair[0]])
+                            ec = center(features["boxs"][id][pair[1]])
+                            draw.line((sc, ec), fill="grey", width=3)
+                            middle_point = ((sc[0] + ec[0]) / 2, (sc[1] + ec[1]) / 2)
+                            draw.text(middle_point, str(angles[p]), fill="black")
+                            draw.rectangle(features["boxs"][id][pair[0]], fill="red")
+                            draw.rectangle(features["boxs"][id][pair[1]], fill="blue")
+
+                    img.save("esempi/FUNSD/edges.png")
 
         return chunks, len(chunks)
-    
-    def get_info(self):
-        print(f"-> textual feats: {self.add_embs}\n-> visual feats: {self.add_visual}\n-> edge feats: {self.add_eweights}")
 
-    
+    def get_info(self):
+        print(
+            f"-> textual feats: {self.add_embs}\n-> visual feats: {self.add_visual}\n-> edge feats: {self.add_eweights}"
+        )

--- a/doc2graph/data/feature_builder.py
+++ b/doc2graph/data/feature_builder.py
@@ -1,0 +1,165 @@
+import random
+from typing import Tuple
+import spacy
+import torch
+import torchvision
+from tqdm import tqdm
+from PIL import Image, ImageDraw
+import torchvision.transforms.functional as tvF
+
+from src.paths import CHECKPOINTS
+from src.models.unet import Unet
+from src.data.utils import to_bin
+from src.data.utils import polar, get_histogram
+from src.utils import get_config
+
+class FeatureBuilder():
+
+    def __init__(self, d : int = 'cpu'):
+        """FeatureBuilder constructor
+
+        Args:
+            d (int): device number, if any (cpu or cuda:n)
+        """
+        self.cfg_preprocessing = get_config('preprocessing')
+        self.device = d
+        self.add_geom = self.cfg_preprocessing.FEATURES.add_geom
+        self.add_embs = self.cfg_preprocessing.FEATURES.add_embs
+        self.add_hist = self.cfg_preprocessing.FEATURES.add_hist
+        self.add_visual = self.cfg_preprocessing.FEATURES.add_visual
+        self.add_eweights = self.cfg_preprocessing.FEATURES.add_eweights
+        self.add_fudge = self.cfg_preprocessing.FEATURES.add_fudge
+        self.num_polar_bins = self.cfg_preprocessing.FEATURES.num_polar_bins
+
+        if self.add_embs:
+            self.text_embedder = spacy.load('en_core_web_lg')
+
+        if self.add_visual:
+            self.visual_embedder = Unet(encoder_name="mobilenet_v2", encoder_weights=None, in_channels=1, classes=4)
+            self.visual_embedder.load_state_dict(torch.load(CHECKPOINTS / 'backbone_unet.pth')['weights'])
+            self.visual_embedder = self.visual_embedder.encoder
+            self.visual_embedder.to(d)
+        
+        self.sg = lambda rect, s : [rect[0]/s[0], rect[1]/s[1], rect[2]/s[0], rect[3]/s[1]] # scaling by img width and height
+    
+    def add_features(self, graphs : list, features : list) -> Tuple[list, int]:
+        """ Add features to provided graphs
+
+        Args:
+            graphs (list) : list of DGLGraphs
+            features (list) : list of features "sources", like text, positions and images
+        
+        Returns:
+            chunks list and its lenght
+        """
+
+        for id, g in enumerate(tqdm(graphs, desc='adding features')):
+
+            # positional features
+            size = Image.open(features['paths'][id]).size
+            feats = [[] for _ in range(len(features['boxs'][id]))]
+            geom = [self.sg(box, size) for box in features['boxs'][id]]
+            chunks = []
+
+            # 'geometrical' features
+            if self.add_geom:
+                
+                # TODO add 2d encoding like "LayoutLM*"
+                [feats[idx].extend(self.sg(box, size)) for idx, box in enumerate(features['boxs'][id])]
+                chunks.append(4)
+            
+            # HISTOGRAM OF TEXT
+            if self.add_hist:
+                
+                [feats[idx].extend(hist) for idx, hist in enumerate(get_histogram(features['texts'][id]))]
+                chunks.append(4)
+            
+            # textual features
+            if self.add_embs:
+                
+                # LANGUAGE MODEL (SPACY)
+                [feats[idx].extend(self.text_embedder(features['texts'][id][idx]).vector) for idx, _ in enumerate(feats)]
+                chunks.append(len(self.text_embedder(features['texts'][id][0]).vector))
+            
+            # visual features
+            # https://pytorch.org/vision/stable/generated/torchvision.ops.roi_align.html?highlight=roi
+            if self.add_visual:
+                img = Image.open(features['paths'][id])
+                visual_emb = self.visual_embedder(tvF.to_tensor(img).unsqueeze_(0).to(self.device)) # output [batch, channels, dim1, dim2]
+                bboxs = [torch.Tensor(b) for b in features['boxs'][id]]
+                bboxs = [torch.stack(bboxs, dim=0).to(self.device)]
+                h = [torchvision.ops.roi_align(input=ve, boxes=bboxs, spatial_scale=1/ min(size[1] / ve.shape[2] , size[0] / ve.shape[3]), output_size=1) for ve in visual_emb[1:]]
+                h = torch.cat(h, dim=1)
+
+                # VISUAL FEATURES (RESNET-IMAGENET)
+                [feats[idx].extend(torch.flatten(h[idx]).tolist()) for idx, _ in enumerate(feats)]
+                chunks.append(len(torch.flatten(h[0]).tolist()))
+        
+            if self.add_eweights:
+                u, v = g.edges()
+                srcs, dsts =  u.tolist(), v.tolist()
+                distances = []
+                angles = []
+
+                # TODO CHOOSE WHICH DISTANCE NORMALIZATION TO APPLY
+                #! with fully connected simply normalized with max distance between distances
+                # m = sqrt((size[0]*size[0] + size[1]*size[1]))
+                # parable = lambda x : (-x+1)**4
+                
+                for pair in zip(srcs, dsts):
+                    dist, angle = polar(features['boxs'][id][pair[0]], features['boxs'][id][pair[1]])
+                    distances.append(dist)
+                    angles.append(angle)
+                
+                m = max(distances)
+                polar_coordinates = to_bin(distances, angles, self.num_polar_bins)
+                g.edata['feat'] = polar_coordinates
+
+            else:
+                distances = ([0.0 for _ in range(g.number_of_edges())])
+                m = 1
+
+            g.ndata['geom'] = torch.tensor(geom, dtype=torch.float32)
+            g.ndata['feat'] = torch.tensor(feats, dtype=torch.float32)
+
+            distances = torch.tensor([(1-d/m) for d in distances], dtype=torch.float32)
+            tresh_dist = torch.where(distances > 0.9, torch.full_like(distances, 0.1), torch.zeros_like(distances))
+            g.edata['weights'] = tresh_dist
+
+            norm = []
+            num_nodes = len(features['boxs'][id]) - 1
+            for n in range(num_nodes + 1):
+                neigs = torch.count_nonzero(tresh_dist[n*num_nodes:(n+1)*num_nodes]).tolist()
+                try: norm.append([1. / neigs])
+                except: norm.append([1.])
+            g.ndata['norm'] = torch.tensor(norm, dtype=torch.float32)
+
+            #! DEBUG PURPOSES TO VISUALIZE RANDOM GRAPH IMAGE FROM DATASET
+            if False:
+                if id == rand_id and self.add_eweights:
+                    print("\n\n### EXAMPLE ###")
+
+                    img_path = features['paths'][id]
+                    img = Image.open(img_path).convert('RGB')
+                    draw = ImageDraw.Draw(img)
+
+                    center = lambda rect: ((rect[2]+rect[0])/2, (rect[3]+rect[1])/2)
+                    select = [random.randint(0, len(srcs)) for _ in range(10)]
+                    for p, pair in enumerate(zip(srcs, dsts)):
+                        if p in select:
+                            sc = center(features['boxs'][id][pair[0]])
+                            ec = center(features['boxs'][id][pair[1]])
+                            draw.line((sc, ec), fill='grey', width=3)
+                            middle_point = ((sc[0] + ec[0])/2,(sc[1] + ec[1])/2)
+                            draw.text(middle_point, str(angles[p]), fill='black')
+                            draw.rectangle(features['boxs'][id][pair[0]], fill='red')
+                            draw.rectangle(features['boxs'][id][pair[1]], fill='blue')
+                    
+                    img.save(f'esempi/FUNSD/edges.png')
+
+        return chunks, len(chunks)
+    
+    def get_info(self):
+        print(f"-> textual feats: {self.add_embs}\n-> visual feats: {self.add_visual}\n-> edge feats: {self.add_eweights}")
+
+    

--- a/doc2graph/data/graph_builder.py
+++ b/doc2graph/data/graph_builder.py
@@ -1,0 +1,461 @@
+import json
+import os
+from PIL import Image, ImageDraw
+from typing import Tuple
+import torch
+import dgl
+import random
+import numpy as np
+from tqdm import tqdm
+import xml.etree.ElementTree as ET
+import easyocr
+
+from src.data.preprocessing import load_predictions
+from src.data.utils import polar
+from src.paths import DATA, FUNSD_TEST
+from src.utils import get_config
+
+
+class GraphBuilder():
+
+    def __init__(self):
+        self.cfg_preprocessing = get_config('preprocessing')
+        self.edge_type = self.cfg_preprocessing.GRAPHS.edge_type
+        self.data_type = self.cfg_preprocessing.GRAPHS.data_type
+        self.node_granularity = self.cfg_preprocessing.GRAPHS.node_granularity
+        random.seed = 42
+        return
+    
+    def get_graph(self, src_path : str, src_data : str) -> Tuple[list, list, list, list]:
+        """ Given the source, it returns a graph
+
+        Args:
+            src_path (str) : path to source data
+            src_data (str) : either FUNSD, PAU or CUSTOM
+        
+        Returns:
+            tuple (lists) : graphs, nodes and edge labels, features
+        """
+        
+        if src_data == 'FUNSD':
+            return self.__fromFUNSD(src_path)
+        elif src_data == 'PAU':
+            return self.__fromPAU(src_path)
+        elif src_data == 'CUSTOM':
+            if self.data_type == 'img':
+                return self.__fromIMG(src_path)
+            elif self.data_type == 'pdf':
+                return self.__fromPDF()
+            else:
+                raise Exception('GraphBuilder exception: data type invalid. Choose from ["img", "pdf"]')
+        else:
+            raise Exception('GraphBuilder exception: source data invalid. Choose from ["FUNSD", "PAU", "CUSTOM"]')
+    
+    def balance_edges(self, g : dgl.DGLGraph, cls=None ) -> dgl.DGLGraph:
+        """ if cls (class) is not None, but an integer instead, balance that class to be equal to the sum of the other classes
+
+        Args:
+            g (DGLGraph) : a DGL graph
+            cls (int) : class number, if any
+        
+        Returns:
+            g (DGLGraph) : the new balanced graph
+        """
+        
+        edge_targets = g.edata['label']
+        u, v = g.all_edges(form='uv')
+        edges_list = list()
+        for e in zip(u.tolist(), v.tolist()):
+            edges_list.append([e[0], e[1]])
+
+        if type(cls) is int:
+            to_remove = (edge_targets == cls)
+            indices_to_remove = to_remove.nonzero().flatten().tolist()
+
+            for _ in range(int((edge_targets != cls).sum()/2)):
+                indeces_to_save = [random.choice(indices_to_remove)]
+                edge = edges_list[indeces_to_save[0]]
+
+                for index in sorted(indeces_to_save, reverse=True):
+                    del indices_to_remove[indices_to_remove.index(index)]
+
+            indices_to_remove = torch.flatten(torch.tensor(indices_to_remove, dtype=torch.int32))
+            g = dgl.remove_edges(g, indices_to_remove)
+            return g
+            
+        else:
+            raise Exception("Select a class to balance (an integer ranging from 0 to num_edge_classes).")
+    
+    def get_info(self):
+        """ returns graph information
+        """
+        print(f"-> edge type: {self.edge_type}")
+
+    def fully_connected(self, ids : list) -> Tuple[list, list]:
+        """ create fully connected graph
+
+        Args:
+            ids (list) : list of node indices
+        
+        Returns:
+            u, v (lists) : lists of indices
+        """
+        u, v = list(), list()
+        for id in ids:
+            u.extend([id for i in range(len(ids)) if i != id])
+            v.extend([i for i in range(len(ids)) if i != id])
+        return u, v
+    
+    def knn_connection(self, size : tuple, bboxs : list, k = 10) -> Tuple[list, list]:
+        """ Given a list of bounding boxes, find for each of them their k nearest ones.
+
+        Args:
+            size (tuple) : width and height of the image
+            bboxs (list) : list of bounding box coordinates
+            k (int) : k of the knn algorithm
+        
+        Returns:
+            u, v (lists) : lists of indices
+        """
+
+        edges = []
+        width, height = size[0], size[1]
+        
+        # creating projections
+        vertical_projections = [[] for i in range(width)]
+        horizontal_projections = [[] for i in range(height)]
+        for node_index, bbox in enumerate(bboxs):
+            for hp in range(bbox[0], bbox[2]):
+                if hp >= width: hp = width - 1
+                vertical_projections[hp].append(node_index)
+            for vp in range(bbox[1], bbox[3]):
+                if vp >= height: vp = height - 1
+                horizontal_projections[vp].append(node_index)
+        
+        def bound(a, ori=''):
+            if a < 0 : return 0
+            elif ori == 'h' and a > height: return height
+            elif ori == 'w' and a > width: return width
+            else: return a
+
+        for node_index, node_bbox in enumerate(bboxs):
+            neighbors = [] # collect list of neighbors
+            window_multiplier = 2 # how much to look around bbox
+            wider = (node_bbox[2] - node_bbox[0]) > (node_bbox[3] - node_bbox[1]) # if bbox wider than taller
+            
+            ### finding neighbors ###
+            while(len(neighbors) < k and window_multiplier < 100): # keep enlarging the window until at least k bboxs are found or window too big
+                vertical_bboxs = []
+                horizontal_bboxs = []
+                neighbors = []
+                
+                if wider:
+                    h_offset = int((node_bbox[2] - node_bbox[0]) * window_multiplier/4)
+                    v_offset = int((node_bbox[3] - node_bbox[1]) * window_multiplier)
+                else:
+                    h_offset = int((node_bbox[2] - node_bbox[0]) * window_multiplier)
+                    v_offset = int((node_bbox[3] - node_bbox[1]) * window_multiplier/4)
+                
+                window = [bound(node_bbox[0] - h_offset),
+                        bound(node_bbox[1] - v_offset),
+                        bound(node_bbox[2] + h_offset, 'w'),
+                        bound(node_bbox[3] + v_offset, 'h')] 
+                
+                [vertical_bboxs.extend(d) for d in vertical_projections[window[0]:window[2]]]
+                [horizontal_bboxs.extend(d) for d in horizontal_projections[window[1]:window[3]]]
+                
+                for v in set(vertical_bboxs):
+                    for h in set(horizontal_bboxs):
+                        if v == h: neighbors.append(v)
+                
+                window_multiplier += 1 # enlarge the window
+            
+            ### finding k nearest neighbors ###
+            neighbors = list(set(neighbors))
+            if node_index in neighbors:
+                neighbors.remove(node_index)
+            neighbors_distances = [polar(node_bbox, bboxs[n])[0] for n in neighbors]
+            for sd_num, sd_idx in enumerate(np.argsort(neighbors_distances)):
+                if sd_num < k:
+                    if [node_index, neighbors[sd_idx]] not in edges and [neighbors[sd_idx], node_index] not in edges:
+                        edges.append([neighbors[sd_idx], node_index])
+                        edges.append([node_index, neighbors[sd_idx]])
+                else: break
+
+        return [e[0] for e in edges], [e[1] for e in edges]
+    
+    def __fromIMG(self, paths : list):
+        
+        graphs, node_labels, edge_labels = list(), list(), list()
+        features = {'paths': paths, 'texts': [], 'boxs': []}
+
+        for path in paths:
+            reader = easyocr.Reader(['en']) #! TODO: in the future, handle multilanguage!
+            result = reader.readtext(path, paragraph=True)
+            img = Image.open(path).convert('RGB')
+            draw = ImageDraw.Draw(img)
+            boxs, texts = list(), list()
+
+            for r in result:
+                box = [int(r[0][0][0]), int(r[0][0][1]), int(r[0][2][0]), int(r[0][2][1])]
+                draw.rectangle(box, outline='red', width=3)
+                boxs.append(box)
+                texts.append(r[1])
+
+            features['boxs'].append(boxs)
+            features['texts'].append(texts)
+            img.save('prova.png')
+
+            if self.edge_type == 'fully':
+                u, v = self.fully_connected(range(len(boxs)))
+            elif self.edge_type == 'knn': 
+                u,v = self.knn_connection(Image.open(path).size, boxs)
+            else:
+                raise Exception('Other edge types still under development.')
+
+            g = dgl.graph((torch.tensor(u), torch.tensor(v)), num_nodes=len(boxs), idtype=torch.int32)
+            graphs.append(g)
+
+        return graphs, node_labels, edge_labels, features
+    
+    def __fromPDF():
+        #TODO: dev from PDF import of graphs
+        return
+
+    def __fromPAU(self, src: str) -> Tuple[list, list, list, list]:
+        """ build graphs from Pau Riba's dataset
+
+        Args:
+            src (str) : path to where data is stored
+        
+        Returns:
+            tuple (lists) : graphs, nodes and edge labels, features
+        """
+
+        graphs, node_labels, edge_labels = list(), list(), list()
+        features = {'paths': [], 'texts': [], 'boxs': []}
+
+        for image in tqdm(os.listdir(src), desc='Creating graphs'):
+            if not image.endswith('tif'): continue
+            
+            img_name = image.split('.')[0]
+            file_gt = img_name + '_gt.xml'
+            file_ocr = img_name + '_ocr.xml'
+            
+            if not os.path.isfile(os.path.join(src, file_gt)) or not os.path.isfile(os.path.join(src, file_ocr)): continue
+            features['paths'].append(os.path.join(src, image))
+
+            # DOCUMENT REGIONS
+            root = ET.parse(os.path.join(src, file_gt)).getroot()
+            regions = []
+            for parent in root:
+                if parent.tag.split("}")[1] == 'Page':
+                    for child in parent:
+                        region_label = child[0].attrib['value']
+                        region_bbox = [int(child[1].attrib['points'].split(" ")[0].split(",")[0].split(".")[0]),
+                                    int(child[1].attrib['points'].split(" ")[1].split(",")[1].split(".")[0]),
+                                    int(child[1].attrib['points'].split(" ")[2].split(",")[0].split(".")[0]),
+                                    int(child[1].attrib['points'].split(" ")[3].split(",")[1].split(".")[0])]
+                        regions.append([region_label, region_bbox])
+
+            # DOCUMENT TOKENS
+            root = ET.parse(os.path.join(src, file_ocr)).getroot()
+            tokens_bbox = []
+            tokens_text = []
+            nl = []
+            center = lambda rect: ((rect[2]+rect[0])/2, (rect[3]+rect[1])/2)
+            for parent in root:
+                if parent.tag.split("}")[1] == 'Page':
+                    for child in parent:
+                        if child.tag.split("}")[1] == 'TextRegion':
+                            for elem in child:
+                                if elem.tag.split("}")[1] == 'TextLine':
+                                    for word in elem:
+                                        if word.tag.split("}")[1] == 'Word':
+                                            word_bbox = [int(word[0].attrib['points'].split(" ")[0].split(",")[0].split(".")[0]),
+                                                        int(word[0].attrib['points'].split(" ")[1].split(",")[1].split(".")[0]),
+                                                        int(word[0].attrib['points'].split(" ")[2].split(",")[0].split(".")[0]),
+                                                        int(word[0].attrib['points'].split(" ")[3].split(",")[1].split(".")[0])]
+                                            word_text = word[1][0].text
+                                            c = center(word_bbox)
+                                            for reg in regions:
+                                                r = reg[1]
+                                                if r[0] < c[0] < r[2] and r[1] < c[1] < r[3]:
+                                                    word_label = reg[0]
+                                                    break
+                                            tokens_bbox.append(word_bbox)
+                                            tokens_text.append(word_text)
+                                            nl.append(word_label)
+            
+            features['boxs'].append(tokens_bbox)
+            features['texts'].append(tokens_text)
+            node_labels.append(nl)
+
+            # getting edges
+            if self.edge_type == 'fully':
+                u, v = self.fully_connected(range(len(tokens_bbox)))
+            elif self.edge_type == 'knn': 
+                u,v = self.knn_connection(Image.open(os.path.join(src, image)).size, tokens_bbox)
+            else:
+                raise Exception('Other edge types still under development.')
+            
+            el = list()
+            for e in zip(u, v):
+                if (nl[e[0]] == nl[e[1]]) and (nl[e[0]] == 'positions' or nl[e[0]] == 'total'):
+                    el.append('table')
+                else: el.append('none')
+            edge_labels.append(el)
+
+            g = dgl.graph((torch.tensor(u), torch.tensor(v)), num_nodes=len(tokens_bbox), idtype=torch.int32)
+            graphs.append(g)
+        
+        return graphs, node_labels, edge_labels, features
+
+    def __fromFUNSD(self, src : str) -> Tuple[list, list, list, list]:
+        """Parsing FUNSD annotation files
+
+        Args:
+            src (str) : path to where data is stored
+        
+        Returns:
+            tuple (lists) : graphs, nodes and edge labels, features
+        """
+
+        graphs, node_labels, edge_labels = list(), list(), list()
+        features = {'paths': [], 'texts': [], 'boxs': []}
+        # justOne = random.choice(os.listdir(os.path.join(src, 'adjusted_annotations'))).split(".")[0]
+        
+        if self.node_granularity == 'gt':
+            for file in tqdm(os.listdir(os.path.join(src, 'adjusted_annotations')), desc='Creating graphs - GT'):
+            
+                img_name = f'{file.split(".")[0]}.png'
+                img_path = os.path.join(src, 'images', img_name)
+                features['paths'].append(img_path)
+
+                with open(os.path.join(src, 'adjusted_annotations', file), 'r') as f:
+                    form = json.load(f)['form']
+
+                # getting infos
+                boxs, texts, ids, nl = list(), list(), list(), list()
+                pair_labels = list()
+
+                for elem in form:
+                    boxs.append(elem['box'])
+                    texts.append(elem['text'])
+                    nl.append(elem['label'])
+                    ids.append(elem['id'])
+                    [pair_labels.append(pair) for pair in elem['linking']]
+                
+                for p, pair in enumerate(pair_labels):
+                    pair_labels[p] = [ids.index(pair[0]), ids.index(pair[1])]
+                
+                node_labels.append(nl)
+                features['texts'].append(texts)
+                features['boxs'].append(boxs)
+                
+                # getting edges
+                if self.edge_type == 'fully':
+                    u, v = self.fully_connected(range(len(boxs)))
+                elif self.edge_type == 'knn': 
+                    u,v = self.knn_connection(Image.open(img_path).size, boxs)
+                else:
+                    raise Exception('GraphBuilder exception: Other edge types still under development.')
+                
+                el = list()
+                for e in zip(u, v):
+                    edge = [e[0], e[1]]
+                    if edge in pair_labels: el.append('pair')
+                    else: el.append('none')
+                edge_labels.append(el)
+
+                # creating graph
+                g = dgl.graph((torch.tensor(u), torch.tensor(v)), num_nodes=len(boxs), idtype=torch.int32)
+                graphs.append(g)
+
+            #! DEBUG PURPOSES TO VISUALIZE RANDOM GRAPH IMAGE FROM DATASET
+            if False:
+                if justOne == file.split(".")[0]:
+                    print("\n\n### EXAMPLE ###")
+                    print("Savin example:", img_name)
+
+                    edge_unique_labels = np.unique(el)
+                    g.edata['label'] = torch.tensor([np.where(target == edge_unique_labels)[0][0] for target in el])
+
+                    g = self.balance_edges(g, 3, int(np.where('none' == edge_unique_labels)[0][0]))
+
+                    img_removed = Image.open(img_path).convert('RGB')
+                    draw_removed = ImageDraw.Draw(img_removed)
+
+                    for b, box in enumerate(boxs):
+                        if nl[b] == 'header':
+                            color = 'yellow'
+                        elif nl[b] == 'question':
+                            color = 'blue'
+                        elif nl[b] == 'answer':
+                            color = 'green'
+                        else:
+                            color = 'gray'
+                        draw_removed.rectangle(box, outline=color, width=3)
+
+                    u, v = g.all_edges()
+                    labels = g.edata['label'].tolist()
+                    u, v = u.tolist(), v.tolist()
+
+                    center = lambda rect: ((rect[2]+rect[0])/2, (rect[3]+rect[1])/2)
+
+                    num_pair = 0
+                    num_none = 0
+
+                    for p, pair in enumerate(zip(u,v)):
+                        sc = center(boxs[pair[0]])
+                        ec = center(boxs[pair[1]])
+                        if labels[p] == int(np.where('pair' == edge_unique_labels)[0][0]): 
+                            num_pair += 1
+                            color = 'violet'
+                            draw_removed.ellipse([(sc[0]-4,sc[1]-4), (sc[0]+4,sc[1]+4)], fill = 'green', outline='black')
+                            draw_removed.ellipse([(ec[0]-4,ec[1]-4), (ec[0]+4,ec[1]+4)], fill = 'red', outline='black')
+                        else: 
+                            num_none += 1
+                            color='gray'
+                        draw_removed.line((sc,ec), fill=color, width=3)
+                    
+                    print("Balanced Links: None {} | Key-Value {}".format(num_none, num_pair))
+                    img_removed.save(f'esempi/FUNSD/{img_name}_removed_graph.png')
+
+        elif self.node_granularity == 'yolo':
+            path_preds = os.path.join(src, 'yolo_bbox')
+            path_images = os.path.join(src, 'images')
+            path_gts = os.path.join(src, 'adjusted_annotations')
+            all_paths, all_preds, all_links, all_labels, all_texts = load_predictions(path_preds, path_gts, path_images)
+            for f, img_path in enumerate(tqdm(all_paths, desc='Creating graphs - YOLO')):
+            
+                features['paths'].append(img_path)
+                features['boxs'].append(all_preds[f])
+                features['texts'].append(all_texts[f])
+                node_labels.append(all_labels[f])
+                pair_labels = all_links[f]
+
+                # getting edges
+                if self.edge_type == 'fully':
+                    u, v = self.fully_connected(range(len(features['boxs'][f])))
+                elif self.edge_type == 'knn': 
+                    u,v = self.knn_connection(Image.open(img_path).size, features['boxs'][f])
+                else:
+                    raise Exception('GraphBuilder exception: Other edge types still under development.')
+                
+                el = list()
+                for e in zip(u, v):
+                    edge = [e[0], e[1]]
+                    if edge in pair_labels: el.append('pair')
+                    else: el.append('none')
+                edge_labels.append(el)
+
+                # creating graph
+                g = dgl.graph((torch.tensor(u), torch.tensor(v)), num_nodes=len(features['boxs'][f]), idtype=torch.int32)
+                graphs.append(g)
+        else:
+            #TODO develop OCR too
+            raise Exception('GraphBuilder Exception: only \'gt\' or \'yolo\' available for FUNSD.')
+
+
+        return graphs, node_labels, edge_labels, features

--- a/doc2graph/data/graph_builder.py
+++ b/doc2graph/data/graph_builder.py
@@ -1,102 +1,108 @@
 import json
 import os
-from PIL import Image, ImageDraw
-from typing import Tuple
-import torch
-import dgl
 import random
-import numpy as np
-from tqdm import tqdm
 import xml.etree.ElementTree as ET
+from typing import Tuple
+
+import dgl
 import easyocr
+import numpy as np
+import torch
+from PIL import Image, ImageDraw
+from tqdm import tqdm
 
-from src.data.preprocessing import load_predictions
-from src.data.utils import polar
-from src.paths import DATA, FUNSD_TEST
-from src.utils import get_config
+from ..data.preprocessing import load_predictions
+from ..data.utils import polar
+from ..utils import get_config
 
 
-class GraphBuilder():
-
+class GraphBuilder:
     def __init__(self):
-        self.cfg_preprocessing = get_config('preprocessing')
+        self.cfg_preprocessing = get_config("preprocessing")
         self.edge_type = self.cfg_preprocessing.GRAPHS.edge_type
         self.data_type = self.cfg_preprocessing.GRAPHS.data_type
         self.node_granularity = self.cfg_preprocessing.GRAPHS.node_granularity
         random.seed = 42
         return
-    
-    def get_graph(self, src_path : str, src_data : str) -> Tuple[list, list, list, list]:
-        """ Given the source, it returns a graph
+
+    def get_graph(self, src_path: str, src_data: str) -> Tuple[list, list, list, list]:
+        """Given the source, it returns a graph
 
         Args:
             src_path (str) : path to source data
             src_data (str) : either FUNSD, PAU or CUSTOM
-        
+
         Returns:
             tuple (lists) : graphs, nodes and edge labels, features
         """
-        
-        if src_data == 'FUNSD':
+
+        if src_data == "FUNSD":
             return self.__fromFUNSD(src_path)
-        elif src_data == 'PAU':
+        elif src_data == "PAU":
             return self.__fromPAU(src_path)
-        elif src_data == 'CUSTOM':
-            if self.data_type == 'img':
+        elif src_data == "CUSTOM":
+            if self.data_type == "img":
                 return self.__fromIMG(src_path)
-            elif self.data_type == 'pdf':
+            elif self.data_type == "pdf":
                 return self.__fromPDF()
             else:
-                raise Exception('GraphBuilder exception: data type invalid. Choose from ["img", "pdf"]')
+                raise Exception(
+                    'GraphBuilder exception: data type invalid. Choose from ["img", "pdf"]'
+                )
         else:
-            raise Exception('GraphBuilder exception: source data invalid. Choose from ["FUNSD", "PAU", "CUSTOM"]')
-    
-    def balance_edges(self, g : dgl.DGLGraph, cls=None ) -> dgl.DGLGraph:
-        """ if cls (class) is not None, but an integer instead, balance that class to be equal to the sum of the other classes
+            raise Exception(
+                'GraphBuilder exception: source data invalid. Choose from ["FUNSD", "PAU", "CUSTOM"]'
+            )
+
+    def balance_edges(self, g: dgl.DGLGraph, cls=None) -> dgl.DGLGraph:
+        """if cls (class) is not None, but an integer instead, balance that class to be equal to the sum of the other classes
 
         Args:
             g (DGLGraph) : a DGL graph
             cls (int) : class number, if any
-        
+
         Returns:
             g (DGLGraph) : the new balanced graph
         """
-        
-        edge_targets = g.edata['label']
-        u, v = g.all_edges(form='uv')
+
+        edge_targets = g.edata["label"]
+        u, v = g.all_edges(form="uv")
         edges_list = list()
         for e in zip(u.tolist(), v.tolist()):
             edges_list.append([e[0], e[1]])
 
         if type(cls) is int:
-            to_remove = (edge_targets == cls)
+            to_remove = edge_targets == cls
             indices_to_remove = to_remove.nonzero().flatten().tolist()
 
-            for _ in range(int((edge_targets != cls).sum()/2)):
+            for _ in range(int((edge_targets != cls).sum() / 2)):
                 indeces_to_save = [random.choice(indices_to_remove)]
                 edge = edges_list[indeces_to_save[0]]
 
                 for index in sorted(indeces_to_save, reverse=True):
                     del indices_to_remove[indices_to_remove.index(index)]
 
-            indices_to_remove = torch.flatten(torch.tensor(indices_to_remove, dtype=torch.int32))
+            indices_to_remove = torch.flatten(
+                torch.tensor(indices_to_remove, dtype=torch.int32)
+            )
             g = dgl.remove_edges(g, indices_to_remove)
             return g
-            
+
         else:
-            raise Exception("Select a class to balance (an integer ranging from 0 to num_edge_classes).")
-    
+            raise Exception(
+                "Select a class to balance (an integer ranging from 0 to num_edge_classes)."
+            )
+
     def get_info(self):
-        """ returns graph information
-        """
+        """returns graph information"""
         print(f"-> edge type: {self.edge_type}")
 
-    def fully_connected(self, ids : list) -> Tuple[list, list]:
-        """ create fully connected graph
+    def fully_connected(self, ids: list) -> Tuple[list, list]:
+        """create fully connected graph
 
         Args:
             ids (list) : list of node indices
-        
+
         Returns:
             u, v (lists) : lists of indices
         """
@@ -105,71 +111,94 @@ class GraphBuilder():
             u.extend([id for i in range(len(ids)) if i != id])
             v.extend([i for i in range(len(ids)) if i != id])
         return u, v
-    
-    def knn_connection(self, size : tuple, bboxs : list, k = 10) -> Tuple[list, list]:
-        """ Given a list of bounding boxes, find for each of them their k nearest ones.
+
+    def knn_connection(self, size: tuple, bboxs: list, k=10) -> Tuple[list, list]:
+        """Given a list of bounding boxes, find for each of them their k nearest ones.
 
         Args:
             size (tuple) : width and height of the image
             bboxs (list) : list of bounding box coordinates
             k (int) : k of the knn algorithm
-        
+
         Returns:
             u, v (lists) : lists of indices
         """
 
         edges = []
         width, height = size[0], size[1]
-        
+
         # creating projections
         vertical_projections = [[] for i in range(width)]
         horizontal_projections = [[] for i in range(height)]
         for node_index, bbox in enumerate(bboxs):
             for hp in range(bbox[0], bbox[2]):
-                if hp >= width: hp = width - 1
+                if hp >= width:
+                    hp = width - 1
                 vertical_projections[hp].append(node_index)
             for vp in range(bbox[1], bbox[3]):
-                if vp >= height: vp = height - 1
+                if vp >= height:
+                    vp = height - 1
                 horizontal_projections[vp].append(node_index)
-        
-        def bound(a, ori=''):
-            if a < 0 : return 0
-            elif ori == 'h' and a > height: return height
-            elif ori == 'w' and a > width: return width
-            else: return a
+
+        def bound(a, ori=""):
+            if a < 0:
+                return 0
+            elif ori == "h" and a > height:
+                return height
+            elif ori == "w" and a > width:
+                return width
+            else:
+                return a
 
         for node_index, node_bbox in enumerate(bboxs):
-            neighbors = [] # collect list of neighbors
-            window_multiplier = 2 # how much to look around bbox
-            wider = (node_bbox[2] - node_bbox[0]) > (node_bbox[3] - node_bbox[1]) # if bbox wider than taller
-            
+            neighbors = []  # collect list of neighbors
+            window_multiplier = 2  # how much to look around bbox
+            wider = (node_bbox[2] - node_bbox[0]) > (
+                node_bbox[3] - node_bbox[1]
+            )  # if bbox wider than taller
+
             ### finding neighbors ###
-            while(len(neighbors) < k and window_multiplier < 100): # keep enlarging the window until at least k bboxs are found or window too big
+            while (
+                len(neighbors) < k and window_multiplier < 100
+            ):  # keep enlarging the window until at least k bboxs are found or window too big
                 vertical_bboxs = []
                 horizontal_bboxs = []
                 neighbors = []
-                
+
                 if wider:
-                    h_offset = int((node_bbox[2] - node_bbox[0]) * window_multiplier/4)
+                    h_offset = int(
+                        (node_bbox[2] - node_bbox[0]) * window_multiplier / 4
+                    )
                     v_offset = int((node_bbox[3] - node_bbox[1]) * window_multiplier)
                 else:
                     h_offset = int((node_bbox[2] - node_bbox[0]) * window_multiplier)
-                    v_offset = int((node_bbox[3] - node_bbox[1]) * window_multiplier/4)
-                
-                window = [bound(node_bbox[0] - h_offset),
-                        bound(node_bbox[1] - v_offset),
-                        bound(node_bbox[2] + h_offset, 'w'),
-                        bound(node_bbox[3] + v_offset, 'h')] 
-                
-                [vertical_bboxs.extend(d) for d in vertical_projections[window[0]:window[2]]]
-                [horizontal_bboxs.extend(d) for d in horizontal_projections[window[1]:window[3]]]
-                
+                    v_offset = int(
+                        (node_bbox[3] - node_bbox[1]) * window_multiplier / 4
+                    )
+
+                window = [
+                    bound(node_bbox[0] - h_offset),
+                    bound(node_bbox[1] - v_offset),
+                    bound(node_bbox[2] + h_offset, "w"),
+                    bound(node_bbox[3] + v_offset, "h"),
+                ]
+
+                [
+                    vertical_bboxs.extend(d)
+                    for d in vertical_projections[window[0] : window[2]]
+                ]
+                [
+                    horizontal_bboxs.extend(d)
+                    for d in horizontal_projections[window[1] : window[3]]
+                ]
+
                 for v in set(vertical_bboxs):
                     for h in set(horizontal_bboxs):
-                        if v == h: neighbors.append(v)
-                
-                window_multiplier += 1 # enlarge the window
-            
+                        if v == h:
+                            neighbors.append(v)
+
+                window_multiplier += 1  # enlarge the window
+
             ### finding k nearest neighbors ###
             neighbors = list(set(neighbors))
             if node_index in neighbors:
@@ -177,85 +206,129 @@ class GraphBuilder():
             neighbors_distances = [polar(node_bbox, bboxs[n])[0] for n in neighbors]
             for sd_num, sd_idx in enumerate(np.argsort(neighbors_distances)):
                 if sd_num < k:
-                    if [node_index, neighbors[sd_idx]] not in edges and [neighbors[sd_idx], node_index] not in edges:
+                    if [node_index, neighbors[sd_idx]] not in edges and [
+                        neighbors[sd_idx],
+                        node_index,
+                    ] not in edges:
                         edges.append([neighbors[sd_idx], node_index])
                         edges.append([node_index, neighbors[sd_idx]])
-                else: break
+                else:
+                    break
 
         return [e[0] for e in edges], [e[1] for e in edges]
-    
-    def __fromIMG(self, paths : list):
-        
+
+    def __fromIMG(self, paths: list):
         graphs, node_labels, edge_labels = list(), list(), list()
-        features = {'paths': paths, 'texts': [], 'boxs': []}
+        features = {"paths": paths, "texts": [], "boxs": []}
 
         for path in paths:
-            reader = easyocr.Reader(['en']) #! TODO: in the future, handle multilanguage!
+            reader = easyocr.Reader(
+                ["en"]
+            )  #! TODO: in the future, handle multilanguage!
             result = reader.readtext(path, paragraph=True)
-            img = Image.open(path).convert('RGB')
+            img = Image.open(path).convert("RGB")
             draw = ImageDraw.Draw(img)
             boxs, texts = list(), list()
 
             for r in result:
-                box = [int(r[0][0][0]), int(r[0][0][1]), int(r[0][2][0]), int(r[0][2][1])]
-                draw.rectangle(box, outline='red', width=3)
+                box = [
+                    int(r[0][0][0]),
+                    int(r[0][0][1]),
+                    int(r[0][2][0]),
+                    int(r[0][2][1]),
+                ]
+                draw.rectangle(box, outline="red", width=3)
                 boxs.append(box)
                 texts.append(r[1])
 
-            features['boxs'].append(boxs)
-            features['texts'].append(texts)
-            img.save('prova.png')
+            features["boxs"].append(boxs)
+            features["texts"].append(texts)
+            img.save("prova.png")
 
-            if self.edge_type == 'fully':
+            if self.edge_type == "fully":
                 u, v = self.fully_connected(range(len(boxs)))
-            elif self.edge_type == 'knn': 
-                u,v = self.knn_connection(Image.open(path).size, boxs)
+            elif self.edge_type == "knn":
+                u, v = self.knn_connection(Image.open(path).size, boxs)
             else:
-                raise Exception('Other edge types still under development.')
+                raise Exception("Other edge types still under development.")
 
-            g = dgl.graph((torch.tensor(u), torch.tensor(v)), num_nodes=len(boxs), idtype=torch.int32)
+            g = dgl.graph(
+                (torch.tensor(u), torch.tensor(v)),
+                num_nodes=len(boxs),
+                idtype=torch.int32,
+            )
             graphs.append(g)
 
         return graphs, node_labels, edge_labels, features
-    
+
     def __fromPDF():
-        #TODO: dev from PDF import of graphs
+        # TODO: dev from PDF import of graphs
         return
 
     def __fromPAU(self, src: str) -> Tuple[list, list, list, list]:
-        """ build graphs from Pau Riba's dataset
+        """build graphs from Pau Riba's dataset
 
         Args:
             src (str) : path to where data is stored
-        
+
         Returns:
             tuple (lists) : graphs, nodes and edge labels, features
         """
 
         graphs, node_labels, edge_labels = list(), list(), list()
-        features = {'paths': [], 'texts': [], 'boxs': []}
+        features = {"paths": [], "texts": [], "boxs": []}
 
-        for image in tqdm(os.listdir(src), desc='Creating graphs'):
-            if not image.endswith('tif'): continue
-            
-            img_name = image.split('.')[0]
-            file_gt = img_name + '_gt.xml'
-            file_ocr = img_name + '_ocr.xml'
-            
-            if not os.path.isfile(os.path.join(src, file_gt)) or not os.path.isfile(os.path.join(src, file_ocr)): continue
-            features['paths'].append(os.path.join(src, image))
+        for image in tqdm(os.listdir(src), desc="Creating graphs"):
+            if not image.endswith("tif"):
+                continue
+
+            img_name = image.split(".")[0]
+            file_gt = img_name + "_gt.xml"
+            file_ocr = img_name + "_ocr.xml"
+
+            if not os.path.isfile(os.path.join(src, file_gt)) or not os.path.isfile(
+                os.path.join(src, file_ocr)
+            ):
+                continue
+            features["paths"].append(os.path.join(src, image))
 
             # DOCUMENT REGIONS
             root = ET.parse(os.path.join(src, file_gt)).getroot()
             regions = []
             for parent in root:
-                if parent.tag.split("}")[1] == 'Page':
+                if parent.tag.split("}")[1] == "Page":
                     for child in parent:
-                        region_label = child[0].attrib['value']
-                        region_bbox = [int(child[1].attrib['points'].split(" ")[0].split(",")[0].split(".")[0]),
-                                    int(child[1].attrib['points'].split(" ")[1].split(",")[1].split(".")[0]),
-                                    int(child[1].attrib['points'].split(" ")[2].split(",")[0].split(".")[0]),
-                                    int(child[1].attrib['points'].split(" ")[3].split(",")[1].split(".")[0])]
+                        region_label = child[0].attrib["value"]
+                        region_bbox = [
+                            int(
+                                child[1]
+                                .attrib["points"]
+                                .split(" ")[0]
+                                .split(",")[0]
+                                .split(".")[0]
+                            ),
+                            int(
+                                child[1]
+                                .attrib["points"]
+                                .split(" ")[1]
+                                .split(",")[1]
+                                .split(".")[0]
+                            ),
+                            int(
+                                child[1]
+                                .attrib["points"]
+                                .split(" ")[2]
+                                .split(",")[0]
+                                .split(".")[0]
+                            ),
+                            int(
+                                child[1]
+                                .attrib["points"]
+                                .split(" ")[3]
+                                .split(",")[1]
+                                .split(".")[0]
+                            ),
+                        ]
                         regions.append([region_label, region_bbox])
 
             # DOCUMENT TOKENS
@@ -263,113 +336,161 @@ class GraphBuilder():
             tokens_bbox = []
             tokens_text = []
             nl = []
-            center = lambda rect: ((rect[2]+rect[0])/2, (rect[3]+rect[1])/2)
+            center = lambda rect: ((rect[2] + rect[0]) / 2, (rect[3] + rect[1]) / 2)
             for parent in root:
-                if parent.tag.split("}")[1] == 'Page':
+                if parent.tag.split("}")[1] == "Page":
                     for child in parent:
-                        if child.tag.split("}")[1] == 'TextRegion':
+                        if child.tag.split("}")[1] == "TextRegion":
                             for elem in child:
-                                if elem.tag.split("}")[1] == 'TextLine':
+                                if elem.tag.split("}")[1] == "TextLine":
                                     for word in elem:
-                                        if word.tag.split("}")[1] == 'Word':
-                                            word_bbox = [int(word[0].attrib['points'].split(" ")[0].split(",")[0].split(".")[0]),
-                                                        int(word[0].attrib['points'].split(" ")[1].split(",")[1].split(".")[0]),
-                                                        int(word[0].attrib['points'].split(" ")[2].split(",")[0].split(".")[0]),
-                                                        int(word[0].attrib['points'].split(" ")[3].split(",")[1].split(".")[0])]
+                                        if word.tag.split("}")[1] == "Word":
+                                            word_bbox = [
+                                                int(
+                                                    word[0]
+                                                    .attrib["points"]
+                                                    .split(" ")[0]
+                                                    .split(",")[0]
+                                                    .split(".")[0]
+                                                ),
+                                                int(
+                                                    word[0]
+                                                    .attrib["points"]
+                                                    .split(" ")[1]
+                                                    .split(",")[1]
+                                                    .split(".")[0]
+                                                ),
+                                                int(
+                                                    word[0]
+                                                    .attrib["points"]
+                                                    .split(" ")[2]
+                                                    .split(",")[0]
+                                                    .split(".")[0]
+                                                ),
+                                                int(
+                                                    word[0]
+                                                    .attrib["points"]
+                                                    .split(" ")[3]
+                                                    .split(",")[1]
+                                                    .split(".")[0]
+                                                ),
+                                            ]
                                             word_text = word[1][0].text
                                             c = center(word_bbox)
                                             for reg in regions:
                                                 r = reg[1]
-                                                if r[0] < c[0] < r[2] and r[1] < c[1] < r[3]:
+                                                if (
+                                                    r[0] < c[0] < r[2]
+                                                    and r[1] < c[1] < r[3]
+                                                ):
                                                     word_label = reg[0]
                                                     break
                                             tokens_bbox.append(word_bbox)
                                             tokens_text.append(word_text)
                                             nl.append(word_label)
-            
-            features['boxs'].append(tokens_bbox)
-            features['texts'].append(tokens_text)
+
+            features["boxs"].append(tokens_bbox)
+            features["texts"].append(tokens_text)
             node_labels.append(nl)
 
-            # getting edges
-            if self.edge_type == 'fully':
+            # getting edges
+            if self.edge_type == "fully":
                 u, v = self.fully_connected(range(len(tokens_bbox)))
-            elif self.edge_type == 'knn': 
-                u,v = self.knn_connection(Image.open(os.path.join(src, image)).size, tokens_bbox)
+            elif self.edge_type == "knn":
+                u, v = self.knn_connection(
+                    Image.open(os.path.join(src, image)).size, tokens_bbox
+                )
             else:
-                raise Exception('Other edge types still under development.')
-            
+                raise Exception("Other edge types still under development.")
+
             el = list()
             for e in zip(u, v):
-                if (nl[e[0]] == nl[e[1]]) and (nl[e[0]] == 'positions' or nl[e[0]] == 'total'):
-                    el.append('table')
-                else: el.append('none')
+                if (nl[e[0]] == nl[e[1]]) and (
+                    nl[e[0]] == "positions" or nl[e[0]] == "total"
+                ):
+                    el.append("table")
+                else:
+                    el.append("none")
             edge_labels.append(el)
 
-            g = dgl.graph((torch.tensor(u), torch.tensor(v)), num_nodes=len(tokens_bbox), idtype=torch.int32)
+            g = dgl.graph(
+                (torch.tensor(u), torch.tensor(v)),
+                num_nodes=len(tokens_bbox),
+                idtype=torch.int32,
+            )
             graphs.append(g)
-        
+
         return graphs, node_labels, edge_labels, features
 
-    def __fromFUNSD(self, src : str) -> Tuple[list, list, list, list]:
+    def __fromFUNSD(self, src: str) -> Tuple[list, list, list, list]:
         """Parsing FUNSD annotation files
 
         Args:
             src (str) : path to where data is stored
-        
+
         Returns:
             tuple (lists) : graphs, nodes and edge labels, features
         """
 
         graphs, node_labels, edge_labels = list(), list(), list()
-        features = {'paths': [], 'texts': [], 'boxs': []}
+        features = {"paths": [], "texts": [], "boxs": []}
         # justOne = random.choice(os.listdir(os.path.join(src, 'adjusted_annotations'))).split(".")[0]
-        
-        if self.node_granularity == 'gt':
-            for file in tqdm(os.listdir(os.path.join(src, 'adjusted_annotations')), desc='Creating graphs - GT'):
-            
-                img_name = f'{file.split(".")[0]}.png'
-                img_path = os.path.join(src, 'images', img_name)
-                features['paths'].append(img_path)
 
-                with open(os.path.join(src, 'adjusted_annotations', file), 'r') as f:
-                    form = json.load(f)['form']
+        if self.node_granularity == "gt":
+            for file in tqdm(
+                os.listdir(os.path.join(src, "adjusted_annotations")),
+                desc="Creating graphs - GT",
+            ):
+                img_name = f"{file.split('.')[0]}.png"
+                img_path = os.path.join(src, "images", img_name)
+                features["paths"].append(img_path)
+
+                with open(os.path.join(src, "adjusted_annotations", file), "r") as f:
+                    form = json.load(f)["form"]
 
                 # getting infos
                 boxs, texts, ids, nl = list(), list(), list(), list()
                 pair_labels = list()
 
                 for elem in form:
-                    boxs.append(elem['box'])
-                    texts.append(elem['text'])
-                    nl.append(elem['label'])
-                    ids.append(elem['id'])
-                    [pair_labels.append(pair) for pair in elem['linking']]
-                
+                    boxs.append(elem["box"])
+                    texts.append(elem["text"])
+                    nl.append(elem["label"])
+                    ids.append(elem["id"])
+                    [pair_labels.append(pair) for pair in elem["linking"]]
+
                 for p, pair in enumerate(pair_labels):
                     pair_labels[p] = [ids.index(pair[0]), ids.index(pair[1])]
-                
+
                 node_labels.append(nl)
-                features['texts'].append(texts)
-                features['boxs'].append(boxs)
-                
-                # getting edges
-                if self.edge_type == 'fully':
+                features["texts"].append(texts)
+                features["boxs"].append(boxs)
+
+                # getting edges
+                if self.edge_type == "fully":
                     u, v = self.fully_connected(range(len(boxs)))
-                elif self.edge_type == 'knn': 
-                    u,v = self.knn_connection(Image.open(img_path).size, boxs)
+                elif self.edge_type == "knn":
+                    u, v = self.knn_connection(Image.open(img_path).size, boxs)
                 else:
-                    raise Exception('GraphBuilder exception: Other edge types still under development.')
-                
+                    raise Exception(
+                        "GraphBuilder exception: Other edge types still under development."
+                    )
+
                 el = list()
                 for e in zip(u, v):
                     edge = [e[0], e[1]]
-                    if edge in pair_labels: el.append('pair')
-                    else: el.append('none')
+                    if edge in pair_labels:
+                        el.append("pair")
+                    else:
+                        el.append("none")
                 edge_labels.append(el)
 
                 # creating graph
-                g = dgl.graph((torch.tensor(u), torch.tensor(v)), num_nodes=len(boxs), idtype=torch.int32)
+                g = dgl.graph(
+                    (torch.tensor(u), torch.tensor(v)),
+                    num_nodes=len(boxs),
+                    idtype=torch.int32,
+                )
                 graphs.append(g)
 
             #! DEBUG PURPOSES TO VISUALIZE RANDOM GRAPH IMAGE FROM DATASET
@@ -379,83 +500,118 @@ class GraphBuilder():
                     print("Savin example:", img_name)
 
                     edge_unique_labels = np.unique(el)
-                    g.edata['label'] = torch.tensor([np.where(target == edge_unique_labels)[0][0] for target in el])
+                    g.edata["label"] = torch.tensor(
+                        [np.where(target == edge_unique_labels)[0][0] for target in el]
+                    )
 
-                    g = self.balance_edges(g, 3, int(np.where('none' == edge_unique_labels)[0][0]))
+                    g = self.balance_edges(
+                        g, 3, int(np.where("none" == edge_unique_labels)[0][0])
+                    )
 
-                    img_removed = Image.open(img_path).convert('RGB')
+                    img_removed = Image.open(img_path).convert("RGB")
                     draw_removed = ImageDraw.Draw(img_removed)
 
                     for b, box in enumerate(boxs):
-                        if nl[b] == 'header':
-                            color = 'yellow'
-                        elif nl[b] == 'question':
-                            color = 'blue'
-                        elif nl[b] == 'answer':
-                            color = 'green'
+                        if nl[b] == "header":
+                            color = "yellow"
+                        elif nl[b] == "question":
+                            color = "blue"
+                        elif nl[b] == "answer":
+                            color = "green"
                         else:
-                            color = 'gray'
+                            color = "gray"
                         draw_removed.rectangle(box, outline=color, width=3)
 
                     u, v = g.all_edges()
-                    labels = g.edata['label'].tolist()
+                    labels = g.edata["label"].tolist()
                     u, v = u.tolist(), v.tolist()
 
-                    center = lambda rect: ((rect[2]+rect[0])/2, (rect[3]+rect[1])/2)
+                    center = lambda rect: (
+                        (rect[2] + rect[0]) / 2,
+                        (rect[3] + rect[1]) / 2,
+                    )
 
                     num_pair = 0
                     num_none = 0
 
-                    for p, pair in enumerate(zip(u,v)):
+                    for p, pair in enumerate(zip(u, v)):
                         sc = center(boxs[pair[0]])
                         ec = center(boxs[pair[1]])
-                        if labels[p] == int(np.where('pair' == edge_unique_labels)[0][0]): 
+                        if labels[p] == int(
+                            np.where("pair" == edge_unique_labels)[0][0]
+                        ):
                             num_pair += 1
-                            color = 'violet'
-                            draw_removed.ellipse([(sc[0]-4,sc[1]-4), (sc[0]+4,sc[1]+4)], fill = 'green', outline='black')
-                            draw_removed.ellipse([(ec[0]-4,ec[1]-4), (ec[0]+4,ec[1]+4)], fill = 'red', outline='black')
-                        else: 
+                            color = "violet"
+                            draw_removed.ellipse(
+                                [(sc[0] - 4, sc[1] - 4), (sc[0] + 4, sc[1] + 4)],
+                                fill="green",
+                                outline="black",
+                            )
+                            draw_removed.ellipse(
+                                [(ec[0] - 4, ec[1] - 4), (ec[0] + 4, ec[1] + 4)],
+                                fill="red",
+                                outline="black",
+                            )
+                        else:
                             num_none += 1
-                            color='gray'
-                        draw_removed.line((sc,ec), fill=color, width=3)
-                    
-                    print("Balanced Links: None {} | Key-Value {}".format(num_none, num_pair))
-                    img_removed.save(f'esempi/FUNSD/{img_name}_removed_graph.png')
+                            color = "gray"
+                        draw_removed.line((sc, ec), fill=color, width=3)
 
-        elif self.node_granularity == 'yolo':
-            path_preds = os.path.join(src, 'yolo_bbox')
-            path_images = os.path.join(src, 'images')
-            path_gts = os.path.join(src, 'adjusted_annotations')
-            all_paths, all_preds, all_links, all_labels, all_texts = load_predictions(path_preds, path_gts, path_images)
-            for f, img_path in enumerate(tqdm(all_paths, desc='Creating graphs - YOLO')):
-            
-                features['paths'].append(img_path)
-                features['boxs'].append(all_preds[f])
-                features['texts'].append(all_texts[f])
+                    print(
+                        "Balanced Links: None {} | Key-Value {}".format(
+                            num_none, num_pair
+                        )
+                    )
+                    img_removed.save(f"esempi/FUNSD/{img_name}_removed_graph.png")
+
+        elif self.node_granularity == "yolo":
+            path_preds = os.path.join(src, "yolo_bbox")
+            path_images = os.path.join(src, "images")
+            path_gts = os.path.join(src, "adjusted_annotations")
+            all_paths, all_preds, all_links, all_labels, all_texts = load_predictions(
+                path_preds, path_gts, path_images
+            )
+            for f, img_path in enumerate(
+                tqdm(all_paths, desc="Creating graphs - YOLO")
+            ):
+                features["paths"].append(img_path)
+                features["boxs"].append(all_preds[f])
+                features["texts"].append(all_texts[f])
                 node_labels.append(all_labels[f])
                 pair_labels = all_links[f]
 
-                # getting edges
-                if self.edge_type == 'fully':
-                    u, v = self.fully_connected(range(len(features['boxs'][f])))
-                elif self.edge_type == 'knn': 
-                    u,v = self.knn_connection(Image.open(img_path).size, features['boxs'][f])
+                # getting edges
+                if self.edge_type == "fully":
+                    u, v = self.fully_connected(range(len(features["boxs"][f])))
+                elif self.edge_type == "knn":
+                    u, v = self.knn_connection(
+                        Image.open(img_path).size, features["boxs"][f]
+                    )
                 else:
-                    raise Exception('GraphBuilder exception: Other edge types still under development.')
-                
+                    raise Exception(
+                        "GraphBuilder exception: Other edge types still under development."
+                    )
+
                 el = list()
                 for e in zip(u, v):
                     edge = [e[0], e[1]]
-                    if edge in pair_labels: el.append('pair')
-                    else: el.append('none')
+                    if edge in pair_labels:
+                        el.append("pair")
+                    else:
+                        el.append("none")
                 edge_labels.append(el)
 
                 # creating graph
-                g = dgl.graph((torch.tensor(u), torch.tensor(v)), num_nodes=len(features['boxs'][f]), idtype=torch.int32)
+                g = dgl.graph(
+                    (torch.tensor(u), torch.tensor(v)),
+                    num_nodes=len(features["boxs"][f]),
+                    idtype=torch.int32,
+                )
                 graphs.append(g)
         else:
-            #TODO develop OCR too
-            raise Exception('GraphBuilder Exception: only \'gt\' or \'yolo\' available for FUNSD.')
-
+            # TODO develop OCR too
+            raise Exception(
+                "GraphBuilder Exception: only 'gt' or 'yolo' available for FUNSD."
+            )
 
         return graphs, node_labels, edge_labels, features

--- a/doc2graph/data/preprocessing.py
+++ b/doc2graph/data/preprocessing.py
@@ -1,0 +1,253 @@
+import torch
+import torchvision
+import numpy as np
+from scipy.optimize import linprog
+import os
+from PIL import ImageDraw, Image
+import json
+import pytesseract
+from pytesseract import Output
+
+from src.paths import DATA, FUNSD_TEST
+
+
+def scale_back(r, w, h): return [int(r[0]*w),
+                                 int(r[1]*h), int(r[2]*w), int(r[3]*h)]
+
+
+def center(r): return ((r[0] + r[2]) / 2, (r[1] + r[3]) / 2)
+
+
+def isIn(c, r):
+    if c[0] < r[0] or c[0] > r[2]:
+        return False
+    elif c[1] < r[1] or c[1] > r[3]:
+        return False
+    else:
+        return True
+
+
+def match_pred_w_gt(bbox_preds: torch.Tensor, bbox_gts: torch.Tensor, links_pair: list):
+    bbox_iou = torchvision.ops.box_iou(boxes1=bbox_preds, boxes2=bbox_gts)
+    bbox_iou = bbox_iou.numpy()
+
+    A_ub = np.zeros(shape=(
+        bbox_iou.shape[0] + bbox_iou.shape[1], bbox_iou.shape[0] * bbox_iou.shape[1]))
+    for r in range(bbox_iou.shape[0]):
+        st = r * bbox_iou.shape[1]
+        A_ub[r, st:st + bbox_iou.shape[1]] = 1
+    for j in range(bbox_iou.shape[1]):
+        r = j + bbox_iou.shape[0]
+        A_ub[r, j::bbox_iou.shape[1]] = 1
+    b_ub = np.ones(shape=A_ub.shape[0])
+
+    assignaments_score = linprog(
+        c=-bbox_iou.reshape(-1), A_ub=A_ub, b_ub=b_ub, bounds=(0, 1), method="highs-ds")
+    #assignaments_score = linprog(c=-bbox_iou.reshape(-1), bounds=(0, 1), method="highs-ds")
+    # print(assignaments_score)
+    if not assignaments_score.success:
+        print("Optimization FAILED")
+    assignaments_score = assignaments_score.x.reshape(bbox_iou.shape)
+    assignaments_ids = assignaments_score.argmax(axis=1)
+
+    # matched
+    opt_assignaments = {}
+    for idx in range(assignaments_score.shape[0]):
+        if (bbox_iou[idx, assignaments_ids[idx]] > 0.5) and (assignaments_score[idx, assignaments_ids[idx]] > 0.9):
+            opt_assignaments[idx] = assignaments_ids[idx]
+    # unmatched predictions
+    false_positive = [idx for idx in range(
+        bbox_preds.shape[0]) if idx not in opt_assignaments]
+    # unmatched gts
+    false_negative = [idx for idx in range(
+        bbox_gts.shape[0]) if idx not in opt_assignaments.values()]
+
+    gt2pred = {v: k for k, v in opt_assignaments.items()}
+    link_false_neg = []
+    for link in links_pair:
+        if link[0] in false_negative or link[1] in false_negative:
+            link_false_neg.append(link)
+
+    if len(links_pair) != 0:
+        rate = len(link_false_neg) / len(links_pair)
+    else:
+        rate = 0
+    return {"pred2gt": opt_assignaments, "gt2pred": gt2pred, "false_positive": false_positive, "false_negative": false_negative, "n_link_fn": int(len(link_false_neg) / 2), "link_loss": rate, "entity_loss": len(false_positive) / (len(false_positive) + len(opt_assignaments.keys()))}
+
+
+def get_objects(path, mode):
+    # TODO given a document, apply OCR or Yolo to detect either words or entities.
+    return
+
+
+def load_predictions(path_preds, path_gts, path_images, debug=False):
+    # TODO read txt file and pass bounding box to the other function.
+
+    boxs_preds = []
+    boxs_gts = []
+    links_gts = []
+    labels_gts = []
+    texts_ocr = []
+    all_paths = []
+
+    for img in os.listdir(path_images):
+        all_paths.append(os.path.join(path_images, img))
+        w, h = Image.open(os.path.join(path_images, img)).size
+        texts = pytesseract.image_to_data(Image.open(
+            os.path.join(path_images, img)), output_type=Output.DICT)
+        tp = []
+        n_elements = len(texts['level'])
+        for t in range(n_elements):
+            if int(texts['conf'][t]) > 50 and texts['text'][t] != ' ':
+                b = [texts['left'][t], texts['top'][t], texts['left'][t] +
+                     texts['width'][t], texts['top'][t] + texts['height'][t]]
+                tp.append([b, texts['text'][t]])
+        texts_ocr.append(tp)
+        preds_name = img.split(".")[0] + '.txt'
+        with open(os.path.join(path_preds, preds_name), 'r') as preds:
+            lines = preds.readlines()
+            boxs = list()
+            for line in lines:
+                scaled = scale_back([float(c)
+                                    for c in line[:-1].split(" ")[1:]], w, h)
+                sw, sh = scaled[2] / 2, scaled[3] / 2
+                boxs.append([scaled[0] - sw, scaled[1] - sh,
+                            scaled[0] + sw, scaled[1] + sh])
+            boxs_preds.append(boxs)
+
+        gts_name = img.split(".")[0] + '.json'
+        with open(os.path.join(path_gts, gts_name), 'r') as f:
+            form = json.load(f)['form']
+            boxs = list()
+            pair_labels = []
+            ids = []
+            labels = []
+            for elem in form:
+                boxs.append([float(e) for e in elem['box']])
+                ids.append(elem['id'])
+                labels.append(elem['label'])
+                [pair_labels.append(pair) for pair in elem['linking']]
+
+            for p, pair in enumerate(pair_labels):
+                pair_labels[p] = [ids.index(pair[0]), ids.index(pair[1])]
+
+            boxs_gts.append(boxs)
+            links_gts.append(pair_labels)
+            labels_gts.append(labels)
+
+    all_links = []
+    all_preds = []
+    all_labels = []
+    all_texts = []
+    dropped_links = 0
+    dropped_entity = 0
+
+    for p in range(len(boxs_preds)):
+        d = match_pred_w_gt(torch.tensor(
+            boxs_preds[p]), torch.tensor(boxs_gts[p]), links_gts[p])
+        dropped_links += d['link_loss']
+        dropped_entity += d['entity_loss']
+        links = list()
+
+        for link in links_gts[p]:
+            if link[0] in d['false_negative'] or link[1] in d['false_negative']:
+                continue
+            else:
+                links.append([d['gt2pred'][link[0]], d['gt2pred'][link[1]]])
+        all_links.append(links)
+
+        preds = []
+        labels = []
+        texts = []
+        for b, box in enumerate(boxs_preds[p]):
+            if b in d['false_positive']:
+                preds.append(box)
+                labels.append('other')
+            else:
+                gt_id = d['pred2gt'][b]
+                preds.append(box)
+                labels.append(labels_gts[p][gt_id])
+
+            text = ''
+            for tocr in texts_ocr[p]:
+                if isIn(center(tocr[0]), box):
+                    text += tocr[1] + ' '
+
+            texts.append(text)
+
+        all_preds.append(preds)
+        all_labels.append(labels)
+        all_texts.append(texts)
+    print(dropped_links / len(boxs_preds), dropped_entity / len(boxs_preds))
+
+    if debug:
+        # random.seed(35)
+        # rand_idx = random.randint(0, len(os.listdir(path_images)))
+        print(all_texts[0])
+        rand_idx = 0
+        img = Image.open(os.path.join(path_images, os.listdir(
+            path_images)[rand_idx])).convert('RGB')
+        draw = ImageDraw.Draw(img)
+
+        rand_boxs_preds = boxs_preds[rand_idx]
+        rand_boxs_gts = boxs_gts[rand_idx]
+
+        for box in rand_boxs_gts:
+            draw.rectangle(box, outline='blue', width=3)
+        for box in rand_boxs_preds:
+            draw.rectangle(box, outline='red', width=3)
+
+        d = match_pred_w_gt(torch.tensor(rand_boxs_preds),
+                            torch.tensor(rand_boxs_gts), links_gts[rand_idx])
+        print(d)
+        for idx in d['pred2gt'].keys():
+            draw.rectangle(rand_boxs_preds[idx], outline='green', width=3)
+
+        link_true_pos = list()
+        link_false_neg = list()
+        for link in links_gts[rand_idx]:
+            if link[0] in d['false_negative'] or link[1] in d['false_negative']:
+                link_false_neg.append(link)
+                start = rand_boxs_gts[link[0]]
+                end = rand_boxs_gts[link[1]]
+                draw.line((center(start), center(end)), fill='red', width=3)
+            else:
+                link_true_pos.append(link)
+                start = rand_boxs_preds[d['gt2pred'][link[0]]]
+                end = rand_boxs_preds[d['gt2pred'][link[1]]]
+                draw.line((center(start), center(end)), fill='green', width=3)
+
+        precision = 0
+        recall = 0
+        for idx, gt in enumerate(boxs_gts):
+            d = match_pred_w_gt(torch.tensor(
+                boxs_preds[idx]), torch.tensor(gt), links_gts[rand_idx])
+            bbox_true_positive = len(d["pred2gt"])
+            p = bbox_true_positive / \
+                (bbox_true_positive + len(d["false_positive"]))
+            r = bbox_true_positive / \
+                (bbox_true_positive + len(d["false_negative"]))
+            # f1 += (2 * p * r) / (p + r)
+            precision += p
+            recall += r
+
+        precision = precision / len(boxs_gts)
+        recall = recall / len(boxs_gts)
+        f1 = (2 * precision * recall) / (precision + recall)
+        # print(f1, precision, recall)
+
+        img.save('prova.png')
+
+    return all_paths, all_preds, all_links, all_labels, all_texts
+
+
+def save_results():
+    # TODO output json of matching and check with visualization of images.
+    return
+
+
+if __name__ == "__main__":
+    path_preds = DATA / 'FUNSD' / 'test_bbox'
+    path_images = FUNSD_TEST / 'images'
+    path_gts = FUNSD_TEST / 'adjusted_annotations'
+    load_predictions(path_preds, path_gts, path_images, debug=True)

--- a/doc2graph/data/preprocessing.py
+++ b/doc2graph/data/preprocessing.py
@@ -1,21 +1,23 @@
+import json
+import os
+
+import numpy as np
+import pytesseract
 import torch
 import torchvision
-import numpy as np
-from scipy.optimize import linprog
-import os
-from PIL import ImageDraw, Image
-import json
-import pytesseract
+from PIL import Image, ImageDraw
 from pytesseract import Output
+from scipy.optimize import linprog
 
-from src.paths import DATA, FUNSD_TEST
-
-
-def scale_back(r, w, h): return [int(r[0]*w),
-                                 int(r[1]*h), int(r[2]*w), int(r[3]*h)]
+from ..paths import DATA, FUNSD_TEST
 
 
-def center(r): return ((r[0] + r[2]) / 2, (r[1] + r[3]) / 2)
+def scale_back(r, w, h):
+    return [int(r[0] * w), int(r[1] * h), int(r[2] * w), int(r[3] * h)]
+
+
+def center(r):
+    return ((r[0] + r[2]) / 2, (r[1] + r[3]) / 2)
 
 
 def isIn(c, r):
@@ -31,19 +33,24 @@ def match_pred_w_gt(bbox_preds: torch.Tensor, bbox_gts: torch.Tensor, links_pair
     bbox_iou = torchvision.ops.box_iou(boxes1=bbox_preds, boxes2=bbox_gts)
     bbox_iou = bbox_iou.numpy()
 
-    A_ub = np.zeros(shape=(
-        bbox_iou.shape[0] + bbox_iou.shape[1], bbox_iou.shape[0] * bbox_iou.shape[1]))
+    A_ub = np.zeros(
+        shape=(
+            bbox_iou.shape[0] + bbox_iou.shape[1],
+            bbox_iou.shape[0] * bbox_iou.shape[1],
+        )
+    )
     for r in range(bbox_iou.shape[0]):
         st = r * bbox_iou.shape[1]
-        A_ub[r, st:st + bbox_iou.shape[1]] = 1
+        A_ub[r, st : st + bbox_iou.shape[1]] = 1
     for j in range(bbox_iou.shape[1]):
         r = j + bbox_iou.shape[0]
-        A_ub[r, j::bbox_iou.shape[1]] = 1
+        A_ub[r, j :: bbox_iou.shape[1]] = 1
     b_ub = np.ones(shape=A_ub.shape[0])
 
     assignaments_score = linprog(
-        c=-bbox_iou.reshape(-1), A_ub=A_ub, b_ub=b_ub, bounds=(0, 1), method="highs-ds")
-    #assignaments_score = linprog(c=-bbox_iou.reshape(-1), bounds=(0, 1), method="highs-ds")
+        c=-bbox_iou.reshape(-1), A_ub=A_ub, b_ub=b_ub, bounds=(0, 1), method="highs-ds"
+    )
+    # assignaments_score = linprog(c=-bbox_iou.reshape(-1), bounds=(0, 1), method="highs-ds")
     # print(assignaments_score)
     if not assignaments_score.success:
         print("Optimization FAILED")
@@ -53,14 +60,18 @@ def match_pred_w_gt(bbox_preds: torch.Tensor, bbox_gts: torch.Tensor, links_pair
     # matched
     opt_assignaments = {}
     for idx in range(assignaments_score.shape[0]):
-        if (bbox_iou[idx, assignaments_ids[idx]] > 0.5) and (assignaments_score[idx, assignaments_ids[idx]] > 0.9):
+        if (bbox_iou[idx, assignaments_ids[idx]] > 0.5) and (
+            assignaments_score[idx, assignaments_ids[idx]] > 0.9
+        ):
             opt_assignaments[idx] = assignaments_ids[idx]
     # unmatched predictions
-    false_positive = [idx for idx in range(
-        bbox_preds.shape[0]) if idx not in opt_assignaments]
+    false_positive = [
+        idx for idx in range(bbox_preds.shape[0]) if idx not in opt_assignaments
+    ]
     # unmatched gts
-    false_negative = [idx for idx in range(
-        bbox_gts.shape[0]) if idx not in opt_assignaments.values()]
+    false_negative = [
+        idx for idx in range(bbox_gts.shape[0]) if idx not in opt_assignaments.values()
+    ]
 
     gt2pred = {v: k for k, v in opt_assignaments.items()}
     link_false_neg = []
@@ -72,7 +83,16 @@ def match_pred_w_gt(bbox_preds: torch.Tensor, bbox_gts: torch.Tensor, links_pair
         rate = len(link_false_neg) / len(links_pair)
     else:
         rate = 0
-    return {"pred2gt": opt_assignaments, "gt2pred": gt2pred, "false_positive": false_positive, "false_negative": false_negative, "n_link_fn": int(len(link_false_neg) / 2), "link_loss": rate, "entity_loss": len(false_positive) / (len(false_positive) + len(opt_assignaments.keys()))}
+    return {
+        "pred2gt": opt_assignaments,
+        "gt2pred": gt2pred,
+        "false_positive": false_positive,
+        "false_negative": false_negative,
+        "n_link_fn": int(len(link_false_neg) / 2),
+        "link_loss": rate,
+        "entity_loss": len(false_positive)
+        / (len(false_positive) + len(opt_assignaments.keys())),
+    }
 
 
 def get_objects(path, mode):
@@ -93,40 +113,45 @@ def load_predictions(path_preds, path_gts, path_images, debug=False):
     for img in os.listdir(path_images):
         all_paths.append(os.path.join(path_images, img))
         w, h = Image.open(os.path.join(path_images, img)).size
-        texts = pytesseract.image_to_data(Image.open(
-            os.path.join(path_images, img)), output_type=Output.DICT)
+        texts = pytesseract.image_to_data(
+            Image.open(os.path.join(path_images, img)), output_type=Output.DICT
+        )
         tp = []
-        n_elements = len(texts['level'])
+        n_elements = len(texts["level"])
         for t in range(n_elements):
-            if int(texts['conf'][t]) > 50 and texts['text'][t] != ' ':
-                b = [texts['left'][t], texts['top'][t], texts['left'][t] +
-                     texts['width'][t], texts['top'][t] + texts['height'][t]]
-                tp.append([b, texts['text'][t]])
+            if int(texts["conf"][t]) > 50 and texts["text"][t] != " ":
+                b = [
+                    texts["left"][t],
+                    texts["top"][t],
+                    texts["left"][t] + texts["width"][t],
+                    texts["top"][t] + texts["height"][t],
+                ]
+                tp.append([b, texts["text"][t]])
         texts_ocr.append(tp)
-        preds_name = img.split(".")[0] + '.txt'
-        with open(os.path.join(path_preds, preds_name), 'r') as preds:
+        preds_name = img.split(".")[0] + ".txt"
+        with open(os.path.join(path_preds, preds_name), "r") as preds:
             lines = preds.readlines()
             boxs = list()
             for line in lines:
-                scaled = scale_back([float(c)
-                                    for c in line[:-1].split(" ")[1:]], w, h)
+                scaled = scale_back([float(c) for c in line[:-1].split(" ")[1:]], w, h)
                 sw, sh = scaled[2] / 2, scaled[3] / 2
-                boxs.append([scaled[0] - sw, scaled[1] - sh,
-                            scaled[0] + sw, scaled[1] + sh])
+                boxs.append(
+                    [scaled[0] - sw, scaled[1] - sh, scaled[0] + sw, scaled[1] + sh]
+                )
             boxs_preds.append(boxs)
 
-        gts_name = img.split(".")[0] + '.json'
-        with open(os.path.join(path_gts, gts_name), 'r') as f:
-            form = json.load(f)['form']
+        gts_name = img.split(".")[0] + ".json"
+        with open(os.path.join(path_gts, gts_name), "r") as f:
+            form = json.load(f)["form"]
             boxs = list()
             pair_labels = []
             ids = []
             labels = []
             for elem in form:
-                boxs.append([float(e) for e in elem['box']])
-                ids.append(elem['id'])
-                labels.append(elem['label'])
-                [pair_labels.append(pair) for pair in elem['linking']]
+                boxs.append([float(e) for e in elem["box"]])
+                ids.append(elem["id"])
+                labels.append(elem["label"])
+                [pair_labels.append(pair) for pair in elem["linking"]]
 
             for p, pair in enumerate(pair_labels):
                 pair_labels[p] = [ids.index(pair[0]), ids.index(pair[1])]
@@ -143,35 +168,36 @@ def load_predictions(path_preds, path_gts, path_images, debug=False):
     dropped_entity = 0
 
     for p in range(len(boxs_preds)):
-        d = match_pred_w_gt(torch.tensor(
-            boxs_preds[p]), torch.tensor(boxs_gts[p]), links_gts[p])
-        dropped_links += d['link_loss']
-        dropped_entity += d['entity_loss']
+        d = match_pred_w_gt(
+            torch.tensor(boxs_preds[p]), torch.tensor(boxs_gts[p]), links_gts[p]
+        )
+        dropped_links += d["link_loss"]
+        dropped_entity += d["entity_loss"]
         links = list()
 
         for link in links_gts[p]:
-            if link[0] in d['false_negative'] or link[1] in d['false_negative']:
+            if link[0] in d["false_negative"] or link[1] in d["false_negative"]:
                 continue
             else:
-                links.append([d['gt2pred'][link[0]], d['gt2pred'][link[1]]])
+                links.append([d["gt2pred"][link[0]], d["gt2pred"][link[1]]])
         all_links.append(links)
 
         preds = []
         labels = []
         texts = []
         for b, box in enumerate(boxs_preds[p]):
-            if b in d['false_positive']:
+            if b in d["false_positive"]:
                 preds.append(box)
-                labels.append('other')
+                labels.append("other")
             else:
-                gt_id = d['pred2gt'][b]
+                gt_id = d["pred2gt"][b]
                 preds.append(box)
                 labels.append(labels_gts[p][gt_id])
 
-            text = ''
+            text = ""
             for tocr in texts_ocr[p]:
                 if isIn(center(tocr[0]), box):
-                    text += tocr[1] + ' '
+                    text += tocr[1] + " "
 
             texts.append(text)
 
@@ -185,49 +211,52 @@ def load_predictions(path_preds, path_gts, path_images, debug=False):
         # rand_idx = random.randint(0, len(os.listdir(path_images)))
         print(all_texts[0])
         rand_idx = 0
-        img = Image.open(os.path.join(path_images, os.listdir(
-            path_images)[rand_idx])).convert('RGB')
+        img = Image.open(
+            os.path.join(path_images, os.listdir(path_images)[rand_idx])
+        ).convert("RGB")
         draw = ImageDraw.Draw(img)
 
         rand_boxs_preds = boxs_preds[rand_idx]
         rand_boxs_gts = boxs_gts[rand_idx]
 
         for box in rand_boxs_gts:
-            draw.rectangle(box, outline='blue', width=3)
+            draw.rectangle(box, outline="blue", width=3)
         for box in rand_boxs_preds:
-            draw.rectangle(box, outline='red', width=3)
+            draw.rectangle(box, outline="red", width=3)
 
-        d = match_pred_w_gt(torch.tensor(rand_boxs_preds),
-                            torch.tensor(rand_boxs_gts), links_gts[rand_idx])
+        d = match_pred_w_gt(
+            torch.tensor(rand_boxs_preds),
+            torch.tensor(rand_boxs_gts),
+            links_gts[rand_idx],
+        )
         print(d)
-        for idx in d['pred2gt'].keys():
-            draw.rectangle(rand_boxs_preds[idx], outline='green', width=3)
+        for idx in d["pred2gt"].keys():
+            draw.rectangle(rand_boxs_preds[idx], outline="green", width=3)
 
         link_true_pos = list()
         link_false_neg = list()
         for link in links_gts[rand_idx]:
-            if link[0] in d['false_negative'] or link[1] in d['false_negative']:
+            if link[0] in d["false_negative"] or link[1] in d["false_negative"]:
                 link_false_neg.append(link)
                 start = rand_boxs_gts[link[0]]
                 end = rand_boxs_gts[link[1]]
-                draw.line((center(start), center(end)), fill='red', width=3)
+                draw.line((center(start), center(end)), fill="red", width=3)
             else:
                 link_true_pos.append(link)
-                start = rand_boxs_preds[d['gt2pred'][link[0]]]
-                end = rand_boxs_preds[d['gt2pred'][link[1]]]
-                draw.line((center(start), center(end)), fill='green', width=3)
+                start = rand_boxs_preds[d["gt2pred"][link[0]]]
+                end = rand_boxs_preds[d["gt2pred"][link[1]]]
+                draw.line((center(start), center(end)), fill="green", width=3)
 
         precision = 0
         recall = 0
         for idx, gt in enumerate(boxs_gts):
-            d = match_pred_w_gt(torch.tensor(
-                boxs_preds[idx]), torch.tensor(gt), links_gts[rand_idx])
+            d = match_pred_w_gt(
+                torch.tensor(boxs_preds[idx]), torch.tensor(gt), links_gts[rand_idx]
+            )
             bbox_true_positive = len(d["pred2gt"])
-            p = bbox_true_positive / \
-                (bbox_true_positive + len(d["false_positive"]))
-            r = bbox_true_positive / \
-                (bbox_true_positive + len(d["false_negative"]))
-            # f1 += (2 * p * r) / (p + r)
+            p = bbox_true_positive / (bbox_true_positive + len(d["false_positive"]))
+            r = bbox_true_positive / (bbox_true_positive + len(d["false_negative"]))
+            # f1 += (2 * p * r) / (p + r)
             precision += p
             recall += r
 
@@ -236,7 +265,7 @@ def load_predictions(path_preds, path_gts, path_images, debug=False):
         f1 = (2 * precision * recall) / (precision + recall)
         # print(f1, precision, recall)
 
-        img.save('prova.png')
+        img.save("prova.png")
 
     return all_paths, all_preds, all_links, all_labels, all_texts
 
@@ -247,7 +276,7 @@ def save_results():
 
 
 if __name__ == "__main__":
-    path_preds = DATA / 'FUNSD' / 'test_bbox'
-    path_images = FUNSD_TEST / 'images'
-    path_gts = FUNSD_TEST / 'adjusted_annotations'
+    path_preds = DATA / "FUNSD" / "test_bbox"
+    path_images = FUNSD_TEST / "images"
+    path_gts = FUNSD_TEST / "adjusted_annotations"
     load_predictions(path_preds, path_gts, path_images, debug=True)

--- a/doc2graph/data/utils.py
+++ b/doc2graph/data/utils.py
@@ -1,0 +1,168 @@
+from math import sqrt
+from typing import Tuple
+import cv2
+import numpy as np
+import torch
+import math
+
+def polar(rect_src : list, rect_dst : list) -> Tuple[int, int]:
+    """Compute distance and angle from src to dst bounding boxes (poolar coordinates considering the src as the center)
+    Args:
+        rect_src (list) : source rectangle coordinates
+        rect_dst (list) : destination rectangle coordinates
+    
+    Returns:
+        tuple (ints): distance and angle
+    """
+    
+    # check relative position
+    left = (rect_dst[2] - rect_src[0]) <= 0
+    bottom = (rect_src[3] - rect_dst[1]) <= 0
+    right = (rect_src[2] - rect_dst[0]) <= 0
+    top = (rect_dst[3] - rect_src[1]) <= 0
+    
+    vp_intersect = (rect_src[0] <= rect_dst[2] and rect_dst[0] <= rect_src[2]) # True if two rects "see" each other vertically, above or under
+    hp_intersect = (rect_src[1] <= rect_dst[3] and rect_dst[1] <= rect_src[3]) # True if two rects "see" each other horizontally, right or left
+    rect_intersect = vp_intersect and hp_intersect 
+
+    center = lambda rect: ((rect[2]+rect[0])/2, (rect[3]+rect[1])/2)
+
+    # evaluate reciprocal position
+    sc = center(rect_src)
+    ec = center(rect_dst)
+    new_ec = (ec[0] - sc[0], ec[1] - sc[1])
+    angle = int(math.degrees(math.atan2(new_ec[1], new_ec[0])) % 360)
+    
+    if rect_intersect:
+        return 0, angle
+    elif top and left:
+        a, b = (rect_dst[2] - rect_src[0]), (rect_dst[3] - rect_src[1])
+        return int(sqrt(a**2 + b**2)), angle
+    elif left and bottom:
+        a, b = (rect_dst[2] - rect_src[0]), (rect_dst[1] - rect_src[3])
+        return int(sqrt(a**2 + b**2)), angle
+    elif bottom and right:
+        a, b = (rect_dst[0] - rect_src[2]), (rect_dst[1] - rect_src[3])
+        return int(sqrt(a**2 + b**2)), angle
+    elif right and top:
+        a, b = (rect_dst[0] - rect_src[2]), (rect_dst[3] - rect_src[1])
+        return int(sqrt(a**2 + b**2)), angle
+    elif left:
+        return (rect_src[0] - rect_dst[2]), angle
+    elif right:
+        return (rect_dst[0] - rect_src[2]), angle
+    elif bottom:
+        return (rect_dst[1] - rect_src[3]), angle
+    elif top:
+        return (rect_src[1] - rect_dst[3]), angle
+
+def transform_image(img_path : str, scale_image=1.0) -> torch.Tensor:
+    """ Transform image to torch.Tensor
+
+    Args:
+        img_path (str) : where the image is stored
+        scale_image (float) : how much scale the image
+    """
+
+    np_img = cv2.imread(img_path, cv2.IMREAD_COLOR)
+    width = int(np_img.shape[1] * scale_image)
+    height = int(np_img.shape[0] * scale_image)
+    new_size = (width, height)
+    np_img = cv2.resize(np_img,new_size)
+    img = cv2.cvtColor(np_img, cv2.COLOR_BGR2GRAY)
+    img = img[None,None,:,:]
+    img = img.astype(np.float32)
+    img = torch.from_numpy(img)
+    img = 1.0 - img / 128.0
+    
+    return img
+
+def get_histogram(contents : list) -> list:
+    """Create histogram of content given a text.
+
+    Args;
+        contents (list)
+
+    Returns:
+        list of [x, y, z] - 3-dimension list with float values summing up to 1 where:
+            - x is the % of literals inside the text
+            - y is the % of numbers inside the text
+            - z is the % of other symbols i.e. @, #, .., inside the text
+    """
+    
+    c_histograms = list()
+
+    for token in contents:
+        num_symbols = 0 # all
+        num_literals = 0 # A, B etc.
+        num_figures = 0 # 1, 2, etc.
+        num_others = 0 # !, @, etc.
+        
+        histogram = [0.0000, 0.0000, 0.0000, 0.0000]
+        
+        for symbol in token.replace(" ", ""):
+            if symbol.isalpha():
+                num_literals += 1
+            elif symbol.isdigit():
+                num_figures += 1
+            else:
+                num_others += 1
+            num_symbols += 1
+
+        if num_symbols != 0:
+            histogram[0] = num_literals / num_symbols
+            histogram[1] = num_figures / num_symbols
+            histogram[2] = num_others / num_symbols
+            
+            # keep sum 1 after truncate
+            if sum(histogram) != 1.0:
+                diff = 1.0 - sum(histogram)
+                m = max(histogram) + diff
+                histogram[histogram.index(max(histogram))] = m
+        
+        # if symbols not recognized at all or empty, sum everything at 1 in the last
+        if histogram[0:3] == [0.0,0.0,0.0]:
+            histogram[3] = 1.0
+        
+        c_histograms.append(histogram)
+        
+    return c_histograms
+
+def to_bin(dist :int, angle : int, b=8) -> torch.Tensor:
+    """ Discretize the space into equal "bins": return a distance and angle into a number between 0 and 1.
+
+    Args:
+        dist (int): distance in terms of pixel, given by "polar()" util function
+        angle (int): angle between 0 and 360, given by "polar()" util function
+        b (int): number of bins, MUST be power of 2
+    
+    Returns:
+        torch.Tensor: new distance and angle (binary encoded)
+
+    """
+    def isPowerOfTwo(x):
+        return (x and (not(x & (x - 1))) )
+
+    # dist
+    assert isPowerOfTwo(b)
+    m = max(dist) / b
+    new_dist = []
+    for d in dist:
+        bin = int(d / m)
+        if bin >= b: bin = b - 1
+        bin = [int(x) for x in list('{0:0b}'.format(bin))]
+        while len(bin) < sqrt(b): bin.insert(0, 0)
+        new_dist.append(bin)
+    
+    # angle
+    amplitude = 360 / b
+    new_angle = []
+    for a in angle:
+        bin = (a - amplitude / 2) 
+        bin = int(bin / amplitude)
+        bin = [int(x) for x in list('{0:0b}'.format(bin))]
+        while len(bin) < sqrt(b): bin.insert(0, 0)
+        new_angle.append(bin)
+
+    return torch.cat([torch.tensor(new_dist, dtype=torch.float32), torch.tensor(new_angle, dtype=torch.float32)], dim=1)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "doc2graph"
-version = "0.2.0"
+version = "0.2.1"
 description = "Doc2Graph transforms documents into graphs and exploit a GNN to solve several tasks. "
 readme = "README.md"
 requires-python = ">=3.9,<3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9, <3.12"
 resolution-markers = [
     "python_full_version >= '3.11' and sys_platform == 'darwin'",
@@ -670,7 +670,7 @@ wheels = [
 
 [[package]]
 name = "doc2graph"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "dgl" },


### PR DESCRIPTION
This PR restores the missing `doc2graph/data` package and includes two small fixes:
1) README: correct CLI examples to run modules (use `uv run python -m` / `python -m`).
2) FeatureBuilder: load `backbone_unet.pth` with `map_location=self.device` so checkpoints saved on CUDA can be deserialized on non-CUDA environments.

Refs #22.

## What I observed
On a clean clone, both commands failed:

```bash
# as in current README
uv run doc2graph.main --init

# and the correct module form
uv run python -m doc2graph.main --init
````

Errors:

```
ModuleNotFoundError: No module named 'doc2graph.data'
# referenced from doc2graph/main.py (e.g., `from .data.download import get_data`)
```

Also during training/testing on a CPU-only machine:

```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False.
If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu')
to map your storages to the CPU.
```

## Root cause

During the `src -> package` refactor the `data/` package was dropped, while several modules still import from `.data`.
(see commit d00ae1664745600d97e3d7a4bc3e9538f28ca2e1.)

## Changes in this PR

* Restore the missing `data/` modules under `doc2graph/data`. (recovered via `git restore` from commit 96fcd72ffcda3a604fa0a08a7855342deccbca85)
* README (Quick Start / Training / Testing):

  * `uv run doc2graph.main --init` → `uv run python -m doc2graph.main --init`
  * `python doc2graph.main …` → `python -m doc2graph.main …`
* `FeatureBuilder`: `torch.load(CHECKPOINTS/"backbone_unet.pth", map_location=self.device)` to support CPU/MPS setups.

## Validation

* `uv pip install -e .`
* `uv run python -m doc2graph.main --init` 
* Training (CPU):

  ```bash
  uv run python -m doc2graph.main [SETTINGS] --gpu -1
  ```
* Testing (CPU):

  ```bash
  uv run python -m doc2graph.main --test --weights <path|glob> --gpu -1 [SETTINGS]
  ```
---
![results](https://github.com/user-attachments/assets/b54c1ef1-a44f-4b83-881e-1f9f602e8342)

Happy to adjust the layout if you prefer a different destination for `data/` or to split this into smaller PRs if that helps the review. 